### PR TITLE
Added stability to velocity

### DIFF
--- a/sdk/sensors/sensor_fusion_ekf.h
+++ b/sdk/sensors/sensor_fusion_ekf.h
@@ -29,6 +29,9 @@
 #include "util/rotation.h"
 #include "util/vector.h"
 
+// Aryzon smooth velocity
+#include "sensors/lowpass_filter.h"
+
 namespace cardboard {
 
 // Sensor fusion class that implements an Extended Kalman Filter (EKF) to
@@ -181,6 +184,9 @@ class SensorFusionEkf {
   // Current bias estimate_;
   Vector3 gyroscope_bias_estimate_;
 
+  // Aryzon smooth velocity
+  LowpassFilter *velocityFilter;
+    
   SensorFusionEkf(const SensorFusionEkf&) = delete;
   SensorFusionEkf& operator=(const SensorFusionEkf&) = delete;
 };

--- a/sdk/sensors/sensor_fusion_ekf.h
+++ b/sdk/sensors/sensor_fusion_ekf.h
@@ -24,13 +24,11 @@
 #include "sensors/accelerometer_data.h"
 #include "sensors/gyroscope_bias_estimator.h"
 #include "sensors/gyroscope_data.h"
+#include "sensors/lowpass_filter.h"
 #include "sensors/pose_state.h"
 #include "util/matrix_3x3.h"
 #include "util/rotation.h"
 #include "util/vector.h"
-
-// Aryzon smooth velocity
-#include "sensors/lowpass_filter.h"
 
 namespace cardboard {
 
@@ -184,8 +182,8 @@ class SensorFusionEkf {
   // Current bias estimate_;
   Vector3 gyroscope_bias_estimate_;
 
-  // Aryzon smooth velocity
-  LowpassFilter *velocityFilter;
+  // Filter to smooth velocity vector
+  LowpassFilter velocity_filter_;
     
   SensorFusionEkf(const SensorFusionEkf&) = delete;
   SensorFusionEkf& operator=(const SensorFusionEkf&) = delete;


### PR DESCRIPTION
When prediction is implemented in v1.5.0 as in [this patch](https://github.com/googlevr/cardboard/issues/193#issuecomment-770036424), the view can appear to be a bit unstable. I think the reason for this is because the velocity that is used to predict movement is taken by extrapolating from a single sample point. This causes frequencies higher than possible by human neck movement to get through in the predicted state. My solution for this is to push the velocity vector through a low pass filter. I tried a couple of cutoff frequencies and 6 Hz works well for me.

My knowledge of a Kalman filter is limited, however I can imagine a better result if a predicted value can be taken from that instead of extrapolating from the last point.