### PR TITLE
Set Cardboard params without QR

### DIFF
--- a/sdk/cardboard.cc
+++ b/sdk/cardboard.cc
@@ -344,6 +344,17 @@ void CardboardQrCode_destroy(const uint8_t* encoded_device_params) {
   delete[] encoded_device_params;
 }
 
+void CardboardQrCode_saveDeviceParams(const uint8_t* uri, int size) {
+  if (CARDBOARD_IS_NOT_INITIALIZED() || CARDBOARD_IS_ARG_NULL(uri)) {
+        return;
+  }
+  if (size <= 0) {
+      CARDBOARD_LOGE("[%s : %d] Argument size is not valid. It must be higher than zero.", __FILE__, __LINE__);
+      return;
+  }
+  cardboard::qrcode::saveDeviceParams(uri, size);
+}
+
 void CardboardQrCode_scanQrCodeAndSaveDeviceParams() {
   if (CARDBOARD_IS_NOT_INITIALIZED()) {
     return;
@@ -351,11 +362,11 @@ void CardboardQrCode_scanQrCodeAndSaveDeviceParams() {
   cardboard::qrcode::scanQrCodeAndSaveDeviceParams();
 }
 
-int CardboardQrCode_getQrCodeScanCount() {
+int CardboardQrCode_getDeviceParamsChangedCount() {
   if (CARDBOARD_IS_NOT_INITIALIZED()) {
     return 0;
   }
-  return cardboard::qrcode::getQrCodeScanCount();
+  return cardboard::qrcode::getDeviceParamsChangedCount();
 }
 
 void CardboardQrCode_getCardboardV1DeviceParams(uint8_t** encoded_device_params,

--- a/sdk/include/cardboard.h
+++ b/sdk/include/cardboard.h
@@ -433,17 +433,44 @@ void CardboardQrCode_getSavedDeviceParams(uint8_t** encoded_device_params,
 ///     using cardboard_device.proto.
 void CardboardQrCode_destroy(const uint8_t* encoded_device_params);
 
+/// Saves the encoded device parameters provided by an URI.
+///
+/// @details This function gets the device parameters from the URI passed as a
+///          parameter. Then saves the encoded device parameters provided by
+///          the uri.
+///          Expected URI format for:
+///          Cardboard Viewer v1: https://g.co/cardboard
+///          Cardboard Viewer v2: https://google.com/cardboard/cfd?p=<deviceParams>
+///          URI example for Cardboard Viewer v2:
+///          "https://google.com/cardboard/cfg?p=CgZHb29nbGUSEkNhcmRib2FyZCBJL
+///          08gMjAxNR0rGBU9JQHegj0qEAAASEIAAEhCAABIQgAASEJYADUpXA89OggeZnc-Ej
+///          6aPlAAYAM"
+///          Redirection is also supported up to a maximum of 5 possible
+///          redirects to reach the proper pattern.
+///          URI must have the HTTPS protocol. HTTP is not supported.
+///          Upon termination, it will increment a counter that can be queried
+///          via @see CardboardQrCode_getDeviceParamsChangedCount() when new device
+///          parameters were succesfully saved.
+///
+/// @pre @p uri Must not be null.
+/// @pre @p size Must be greater than 0.
+///
+/// @param[in]      uri                     UTF-8 URI string. See above for
+///                                         supported formats.
+/// @param[in]      size                    Size in bytes of @p uri
+void CardboardQrCode_saveDeviceParams(const uint8_t* uri, int size);
+
 /// Scans a QR code and saves the encoded device parameters.
 ///
 /// @details Upon termination, it will increment a counter that can be queried
-///          via @see CardboardQrCode_getQrCodeScanCount() when new device
-///          parameters where succesfully saved.
+///          via @see CardboardQrCode_getDeviceParamsChangedCount() when new device
+///          parameters were succesfully saved.
 void CardboardQrCode_scanQrCodeAndSaveDeviceParams();
 
 /// Gets the count of successful device parameters read and save operations.
 ///
 /// @return The count of successful device parameters read and save operations.
-int CardboardQrCode_getQrCodeScanCount();
+int CardboardQrCode_getDeviceParamsChangedCount();
 
 /// Gets Cardboard V1 device parameters.
 ///

--- a/sdk/qr_code.h
+++ b/sdk/qr_code.h
@@ -30,7 +30,8 @@ void initializeAndroid(JavaVM* vm, jobject context);
 #endif
 std::vector<uint8_t> getCurrentSavedDeviceParams();
 void scanQrCodeAndSaveDeviceParams();
-int getQrCodeScanCount();
+void saveDeviceParams(const uint8_t* uri, int size);
+int getDeviceParamsChangedCount();
 }  // namespace qrcode
 }  // namespace cardboard
 

--- a/sdk/qrcode/android/java/com/google/cardboard/sdk/QrCodeCaptureActivity.java
+++ b/sdk/qrcode/android/java/com/google/cardboard/sdk/QrCodeCaptureActivity.java
@@ -275,7 +275,7 @@ public class QrCodeCaptureActivity extends AppCompatActivity
     if (status) {
       Log.d(TAG, "Device parameters saved in external storage.");
       cameraSourcePreview.stop();
-      nativeIncrementQrCodeScanCount();
+      nativeIncrementDeviceParamsChangedCount();
       finish();
     } else {
       Log.e(TAG, "Device parameters not saved in external storage.");
@@ -283,5 +283,5 @@ public class QrCodeCaptureActivity extends AppCompatActivity
     qrCodeSaved = false;
   }
 
-  private native void nativeIncrementQrCodeScanCount();
+  private native void nativeIncrementDeviceParamsChangedCount();
 }

--- a/sdk/qrcode/android/java/com/google/cardboard/sdk/qrcode/CardboardParamsUtils.java
+++ b/sdk/qrcode/android/java/com/google/cardboard/sdk/qrcode/CardboardParamsUtils.java
@@ -20,6 +20,7 @@ import android.net.Uri;
 import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import android.os.Environment;
+import android.support.annotation.Nullable;
 import android.util.Base64;
 import android.util.Log;
 import com.google.cardboard.sdk.deviceparams.CardboardV1DeviceParams;
@@ -28,6 +29,8 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.ProtocolException;
 import java.nio.ByteBuffer;
 
 /** Utility methods for managing configuration parameters. */
@@ -64,6 +67,11 @@ public abstract class CardboardParamsUtils {
   /** Flags to encode and decode in Base64 device parameters in the Uri. */
   private static final int URI_CODING_PARAMS = Base64.URL_SAFE | Base64.NO_WRAP | Base64.NO_PADDING;
 
+  private static final int MAX_REDIRECTS = 5;
+  private static final String HTTP_SCHEME_PREFIX = "http://";
+  private static final String HTTPS_SCHEME_PREFIX = "https://";
+  private static final int HTTPS_TIMEOUT_MS = 5 * 1000;
+
   /** Enum to determine which storage source to use. */
   // TODO(b/167382867): Make it private and modify tests.
   private enum StorageSource {
@@ -71,14 +79,109 @@ public abstract class CardboardParamsUtils {
     EXTERNAL_STORAGE
   };
 
+  /** Holds status for conversion from a URI to Cardboard device params. */
+  public static class UriToParamsStatus {
+    public static final int STATUS_OK = 0;
+    public static final int STATUS_UNEXPECTED_FORMAT = 1;
+    public static final int STATUS_CONNECTION_ERROR = 2;
+
+    public final int statusCode;
+    /** Only not null when statusCode is STATUS_OK. */
+    @Nullable
+    public final byte[] params;
+
+    public static UriToParamsStatus success(byte[] params) {
+      return new UriToParamsStatus(STATUS_OK, params);
+    }
+
+    public static UriToParamsStatus error(int statusCode) {
+      return new UriToParamsStatus(statusCode, null);
+    }
+
+    private UriToParamsStatus(int statusCode, @Nullable byte[] params) {
+      this.statusCode = statusCode;
+      this.params = params;
+    }
+  }
+
   /** URI of original cardboard QR code. */
   // TODO(b/170471141): Wifi connection shouldn't be required for Cardboard Viewer v1.0.
   private static final Uri URI_ORIGINAL_CARDBOARD_QR_CODE =
-      new Uri.Builder()
-          .scheme(HTTPS_SCHEME)
-          .authority(URI_HOST_GOOGLE_SHORT)
-          .appendEncodedPath(URI_PATH_CARDBOARD_HOME)
-          .build();
+    new Uri.Builder()
+      .scheme(HTTPS_SCHEME)
+      .authority(URI_HOST_GOOGLE_SHORT)
+      .appendEncodedPath(URI_PATH_CARDBOARD_HOME)
+      .build();
+
+  /**
+   * Converts a bytes array with an URI string to a Uri object.
+   * Obtains the physical parameters of a Cardboard headset from the Uri (as bytes) by
+   * calling {@code getParamsFromUriString}.
+   * Then writes the device parameters to a predefined storage location calling {@code
+   * writeDeviceParams()}.
+   *
+   * @param uriAsBytes A bytes buffer with the URI to read the parameters from.
+   * @param context The current Context. It is generally an Activity instance or wraps one or an
+   *        Application. It is used to write to storage.
+   */
+  private static void saveParamsFromUri(byte[] uriAsBytes, Context context){
+    String uriAsString = new String(uriAsBytes);
+    UriToParamsStatus uriToParamsStatus = getParamsFromUriString(uriAsString, new UrlFactory());
+    // If getParamsFromUri() does not return an OK status don't write the device params
+    if (uriToParamsStatus.statusCode != UriToParamsStatus.STATUS_OK) {
+      Log.e(TAG, "Error when trying to get the Cardboard params from URI: " + uriAsString);
+      return;
+    }
+
+    boolean status = writeDeviceParams(uriToParamsStatus.params, context);
+    Log.d(TAG, "Could " + (!status ? "not " : "") + "write Cardboard parameters to storage.");
+  }
+
+  /**
+   * Attempts to convert an URI received as a string into device parameters.
+   * Analyses the URI obtained from a string in order to get the device parameters. If the obtained
+   * string matches a Cardboard V1 string format, the parameters are taken directly from the code.
+   * If the obtained string matches a Cardboard V2 string format, the parameters are taken from the
+   * URI query string (up to 5 redirections supported). This function only supports HTTPS connections,
+   * so if an HTTP scheme is found, it is replaced by an HTTPS one.
+   *
+   * @param uriAsString a String with the URI to read the parameters from.
+   * @param urlFactory Factory for creating URL instance for HTTPS connection.
+   * @return Cardboard device parameters, or null if there is an error.
+   */
+  public static UriToParamsStatus getParamsFromUriString(String uriAsString, UrlFactory urlFactory){
+    Uri uri = Uri.parse(uriAsString);
+    if (uri == null) {
+      Log.e(TAG, "Error when parsing URI: " + uri.toString());
+      return UriToParamsStatus.error(UriToParamsStatus.STATUS_UNEXPECTED_FORMAT);
+    }
+
+    // If needed, prefix free text results with a https prefix.
+    if (uri.getScheme() == null) {
+      uri = Uri.parse(HTTPS_SCHEME_PREFIX + uri);
+    }
+
+    // Follow redirects to support URL shortening.
+    try {
+      Log.d(TAG, "Following redirects for original URI: " + uri);
+      uri = followCardboardParamRedirect(uri, MAX_REDIRECTS, urlFactory);
+    } catch (IOException e) {
+      Log.w(TAG, "Error while following URL redirect " + e);
+      return UriToParamsStatus.error(UriToParamsStatus.STATUS_CONNECTION_ERROR);
+    }
+
+    if (uri == null) {
+      Log.e(TAG, "Error when following URI redirects");
+      return UriToParamsStatus.error(UriToParamsStatus.STATUS_UNEXPECTED_FORMAT);
+    }
+    byte[] params = CardboardParamsUtils.createFromUri(uri);
+
+    if (params == null) {
+      Log.e(TAG, "Error when parsing device parameters from URI query string: " + uri);
+      return UriToParamsStatus.error(UriToParamsStatus.STATUS_UNEXPECTED_FORMAT);
+    }
+    return UriToParamsStatus.success(params);
+  }
 
   /**
    * Obtains the physical parameters of a Cardboard headset from a Uri (as bytes).
@@ -183,10 +286,10 @@ public abstract class CardboardParamsUtils {
             CARDBOARD_CONFIG_FOLDER);
 
     if (!configFolder.exists()) {
-      configFolder.mkdirs();
+        configFolder.mkdirs();
     } else if (!configFolder.isDirectory()) {
       throw new IllegalStateException(
-          configFolder + " already exists as a file, but is expected to be a directory.");
+        configFolder + " already exists as a file, but is expected to be a directory.");
     }
 
     return new File(configFolder, CARDBOARD_DEVICE_PARAMS_FILE);
@@ -412,5 +515,88 @@ public abstract class CardboardParamsUtils {
     if (!writeDeviceParamsToStorage(deviceParams, storageSource, context)) {
       Log.e(TAG, "Could not write Cardboard parameters to storage.");
     }
+  }
+
+  /**
+   * Follow HTTPS redirect until we reach a valid Cardboard device URI.
+   *
+   * <p>Network access is only used if the given URI is not already a cardboard device. Only HTTPS
+   * headers are transmitted, and the final URI is not accessed.
+   *
+   * @param uri The initial URI.
+   * @param maxRedirects Maximum number of redirects to follow.
+   * @param urlFactory Factory for creating URL instance for HTTPS connection.
+   * @return Cardboard device URI, or null if there is an error.
+   */
+  @Nullable
+  @SuppressWarnings("nullness:assignment.type.incompatible")
+  private static Uri followCardboardParamRedirect(
+          Uri uri, int maxRedirects, final UrlFactory urlFactory) throws IOException {
+    int numRedirects = 0;
+    while (uri != null && !CardboardParamsUtils.isCardboardUri(uri)) {
+      if (numRedirects >= maxRedirects) {
+        Log.d(TAG, "Exceeding the number of maximum redirects: " + maxRedirects);
+        return null;
+      }
+      uri = resolveHttpsRedirect(uri, urlFactory);
+      numRedirects++;
+    }
+    return uri;
+  }
+
+  /**
+   * Dereference an HTTPS redirect without reading resource body.
+   *
+   * @param uri The initial URI.
+   * @param urlFactory Factory for creating URL instance for HTTPS connection.
+   * @return Redirected URI, or null if there is no redirect or an error.
+   */
+  @Nullable
+  private static Uri resolveHttpsRedirect(Uri uri, UrlFactory urlFactory) throws IOException {
+    HttpURLConnection connection = urlFactory.openHttpsConnection(uri);
+    if (connection == null) {
+      return null;
+    }
+    // Rather than follow redirects internally, we follow one hop at the time.
+    // We don't want to issue even a HEAD request to the Cardboard URI.
+    connection.setInstanceFollowRedirects(false);
+    connection.setDoInput(false);
+    connection.setConnectTimeout(HTTPS_TIMEOUT_MS);
+    connection.setReadTimeout(HTTPS_TIMEOUT_MS);
+    // Workaround for Android bug with HEAD requests on KitKat devices.
+    // See: https://code.google.com/p/android/issues/detail?id=24672.
+    connection.setRequestProperty("Accept-Encoding", "");
+    try {
+      connection.setRequestMethod("HEAD");
+    } catch (ProtocolException e) {
+      Log.w(TAG, e.toString());
+      return null;
+    }
+    try {
+      connection.connect();
+      int responseCode = connection.getResponseCode();
+      Log.i(TAG, "Response code: " + responseCode);
+      if (responseCode != HttpURLConnection.HTTP_MOVED_PERM
+              && responseCode != HttpURLConnection.HTTP_MOVED_TEMP) {
+        return null;
+      }
+      String location = connection.getHeaderField("Location");
+      if (location == null) {
+        Log.d(TAG, "Returning null because of null location.");
+        return null;
+      }
+      Log.i(TAG, "Location: " + location);
+
+      Uri redirectUri = Uri.parse(location.replaceFirst(HTTP_SCHEME_PREFIX, HTTPS_SCHEME_PREFIX));
+      if (redirectUri == null || redirectUri.compareTo(uri) == 0) {
+        Log.d(TAG, "Returning null because of wrong redirect URI.");
+        return null;
+      }
+      Log.i(TAG, "Param URI redirect to " + redirectUri);
+      uri = redirectUri;
+    } finally {
+      connection.disconnect();
+    }
+    return uri;
   }
 }

--- a/sdk/qrcode/android/java/com/google/cardboard/sdk/qrcode/QrCodeContentProcessor.java
+++ b/sdk/qrcode/android/java/com/google/cardboard/sdk/qrcode/QrCodeContentProcessor.java
@@ -23,9 +23,6 @@ import android.widget.Toast;
 import android.support.annotation.Nullable;
 import com.google.android.gms.vision.barcode.Barcode;
 import com.google.cardboard.sdk.R;
-import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.net.ProtocolException;
 
 /**
  * Class for processing QR code data. The QR code content should be a URI which has a parameter
@@ -37,11 +34,6 @@ public class QrCodeContentProcessor {
 
   private final Listener listener;
 
-  private static final int MAX_REDIRECTS = 5;
-  private static final String HTTP_SCHEME_PREFIX = "http://";
-  private static final String HTTPS_SCHEME_PREFIX = "https://";
-  private static final int HTTPS_TIMEOUT_MS = 5 * 1000;
-
   public QrCodeContentProcessor(Listener listener) {
     this.listener = listener;
   }
@@ -52,30 +44,6 @@ public class QrCodeContentProcessor {
    */
   public interface Listener {
     void onQrCodeSaved(boolean status);
-  }
-
-  /** Holds status for conversion from raw QR code to Cardboard device params. */
-  public static class QrCodeToParamsStatus {
-    public static final int STATUS_OK = 0;
-    public static final int STATUS_UNEXPECTED_FORMAT = 1;
-    public static final int STATUS_CONNECTION_ERROR = 2;
-
-    public final int statusCode;
-    /** Only not null when statusCode is STATUS_OK. */
-    @Nullable public final byte[] params;
-
-    public static QrCodeToParamsStatus success(byte[] params) {
-      return new QrCodeToParamsStatus(STATUS_OK, params);
-    }
-
-    public static QrCodeToParamsStatus error(int statusCode) {
-      return new QrCodeToParamsStatus(statusCode, null);
-    }
-
-    private QrCodeToParamsStatus(int statusCode, @Nullable byte[] params) {
-      this.statusCode = statusCode;
-      this.params = params;
-    }
   }
 
   /**
@@ -93,7 +61,7 @@ public class QrCodeContentProcessor {
    * Asynchronous Task to process QR code. Once it is processed, obtained parameters are saved in
    * external storage.
    */
-  public class ProcessAndSaveQrCodeTask extends AsyncTask<Barcode, Void, QrCodeToParamsStatus> {
+  public class ProcessAndSaveQrCodeTask extends AsyncTask<Barcode, Void, CardboardParamsUtils.UriToParamsStatus> {
     private final Context context;
 
     /**
@@ -109,19 +77,19 @@ public class QrCodeContentProcessor {
 
     @Override
     @Nullable
-    protected QrCodeToParamsStatus doInBackground(Barcode... qrCode) {
+    protected CardboardParamsUtils.UriToParamsStatus doInBackground(Barcode... qrCode) {
       UrlFactory urlFactory = new UrlFactory();
       return getParamsFromQrCode(qrCode[0], urlFactory);
     }
 
     @Override
-    protected void onPostExecute(QrCodeToParamsStatus result) {
+    protected void onPostExecute(CardboardParamsUtils.UriToParamsStatus result) {
       super.onPostExecute(result);
       boolean status = false;
-      if (result.statusCode == QrCodeToParamsStatus.STATUS_UNEXPECTED_FORMAT) {
+      if (result.statusCode == CardboardParamsUtils.UriToParamsStatus.STATUS_UNEXPECTED_FORMAT) {
         Log.d(TAG, String.valueOf(R.string.invalid_qr_code));
         Toast.makeText(context, R.string.invalid_qr_code, Toast.LENGTH_LONG).show();
-      } else if (result.statusCode == QrCodeToParamsStatus.STATUS_CONNECTION_ERROR) {
+      } else if (result.statusCode == CardboardParamsUtils.UriToParamsStatus.STATUS_CONNECTION_ERROR) {
         Log.d(TAG, String.valueOf(R.string.connection_error));
         Toast.makeText(context, R.string.connection_error, Toast.LENGTH_LONG).show();
       } else if (result.params != null) {
@@ -137,134 +105,20 @@ public class QrCodeContentProcessor {
    * Attempts to convert a QR code detection result into device parameters (as a protobuf).
    *
    * <p>This function analyses the obtained string from a QR code in order to get the device
-   * parameters. If the obtained string matches a Cardboard V1 string format, the parameters are
-   * taken directly from the code. If the obtained string matches a Cardboard V2 string format, the
-   * parameters are taken from the URI query string (up to 5 redirections supported). This function
-   * only supports HTTPS connections, so if an HTTP scheme is found, it is replaced by an HTTPS one.
+   * parameters by calling {@code CardboardParamsUtils.getParamsFromUriString}.
    *
    * @param barcode The detected QR code.
    * @param urlFactory Factory for creating URL instance for HTTPS connection.
    * @return Cardboard device parameters, or null if there is an error.
    */
-  private static QrCodeToParamsStatus getParamsFromQrCode(Barcode barcode, UrlFactory urlFactory) {
+  private static CardboardParamsUtils.UriToParamsStatus getParamsFromQrCode(Barcode barcode, UrlFactory urlFactory) {
     if (barcode.valueFormat != Barcode.TEXT && barcode.valueFormat != Barcode.URL) {
       Log.e(TAG, "Invalid QR code format: " + barcode.valueFormat);
-      return QrCodeToParamsStatus.error(QrCodeToParamsStatus.STATUS_UNEXPECTED_FORMAT);
+      return CardboardParamsUtils.UriToParamsStatus.error(CardboardParamsUtils.UriToParamsStatus.STATUS_UNEXPECTED_FORMAT);
     }
 
-    Uri uri = Uri.parse(barcode.rawValue);
-    if (uri == null) {
-      Log.e(TAG, "Error when parsing scanned URI: " + barcode.rawValue);
-      return QrCodeToParamsStatus.error(QrCodeToParamsStatus.STATUS_UNEXPECTED_FORMAT);
-    }
-
-    // If needed, prefix free text results with a https prefix.
-    if (uri.getScheme() == null) {
-      uri = Uri.parse(HTTPS_SCHEME_PREFIX + uri);
-    }
-
-    // Follow redirects to support URL shortening.
-    try {
-      Log.d(TAG, "Following redirects for original URI: " + uri);
-      uri = followCardboardParamRedirect(uri, MAX_REDIRECTS, urlFactory);
-    } catch (IOException e) {
-      Log.w(TAG, "Error while following URL redirect " + e);
-      return QrCodeToParamsStatus.error(QrCodeToParamsStatus.STATUS_CONNECTION_ERROR);
-    }
-
-    if (uri == null) {
-      Log.e(TAG, "Error when following URI redirects");
-      return QrCodeToParamsStatus.error(QrCodeToParamsStatus.STATUS_UNEXPECTED_FORMAT);
-    }
-
-    byte[] params = CardboardParamsUtils.createFromUri(uri);
-    if (params == null) {
-      Log.e(TAG, "Error when parsing device parameters from URI query string: " + uri);
-      return QrCodeToParamsStatus.error(QrCodeToParamsStatus.STATUS_UNEXPECTED_FORMAT);
-    }
-    return QrCodeToParamsStatus.success(params);
+    return CardboardParamsUtils.getParamsFromUriString(barcode.rawValue, urlFactory);
   }
 
-  /**
-   * Follow HTTPS redirect until we reach a valid Cardboard device URI.
-   *
-   * <p>Network access is only used if the given URI is not already a cardboard device. Only HTTPS
-   * headers are transmitted, and the final URI is not accessed.
-   *
-   * @param uri The initial URI.
-   * @param maxRedirects Maximum number of redirects to follow.
-   * @param urlFactory Factory for creating URL instance for HTTPS connection.
-   * @return Cardboard device URI, or null if there is an error.
-   */
-  @Nullable
-  @SuppressWarnings("nullness:assignment.type.incompatible")
-  private static Uri followCardboardParamRedirect(
-      Uri uri, int maxRedirects, final UrlFactory urlFactory) throws IOException {
-    int numRedirects = 0;
-    while (uri != null && !CardboardParamsUtils.isCardboardUri(uri)) {
-      if (numRedirects >= maxRedirects) {
-        Log.d(TAG, "Exceeding the number of maximum redirects: " + maxRedirects);
-        return null;
-      }
-      uri = resolveHttpsRedirect(uri, urlFactory);
-      numRedirects++;
-    }
-    return uri;
-  }
 
-  /**
-   * Dereference an HTTPS redirect without reading resource body.
-   *
-   * @param uri The initial URI.
-   * @param urlFactory Factory for creating URL instance for HTTPS connection.
-   * @return Redirected URI, or null if there is no redirect or an error.
-   */
-  @Nullable
-  private static Uri resolveHttpsRedirect(Uri uri, UrlFactory urlFactory) throws IOException {
-    HttpURLConnection connection = urlFactory.openHttpsConnection(uri);
-    if (connection == null) {
-      return null;
-    }
-    // Rather than follow redirects internally, we follow one hop at the time.
-    // We don't want to issue even a HEAD request to the Cardboard URI.
-    connection.setInstanceFollowRedirects(false);
-    connection.setDoInput(false);
-    connection.setConnectTimeout(HTTPS_TIMEOUT_MS);
-    connection.setReadTimeout(HTTPS_TIMEOUT_MS);
-    // Workaround for Android bug with HEAD requests on KitKat devices.
-    // See: https://code.google.com/p/android/issues/detail?id=24672.
-    connection.setRequestProperty("Accept-Encoding", "");
-    try {
-      connection.setRequestMethod("HEAD");
-    } catch (ProtocolException e) {
-      Log.w(TAG, e.toString());
-      return null;
-    }
-    try {
-      connection.connect();
-      int responseCode = connection.getResponseCode();
-      Log.i(TAG, "Response code: " + responseCode);
-      if (responseCode != HttpURLConnection.HTTP_MOVED_PERM
-          && responseCode != HttpURLConnection.HTTP_MOVED_TEMP) {
-        return null;
-      }
-      String location = connection.getHeaderField("Location");
-      if (location == null) {
-        Log.d(TAG, "Returning null because of null location.");
-        return null;
-      }
-      Log.i(TAG, "Location: " + location);
-
-      Uri redirectUri = Uri.parse(location.replaceFirst(HTTP_SCHEME_PREFIX, HTTPS_SCHEME_PREFIX));
-      if (redirectUri == null || redirectUri.compareTo(uri) == 0) {
-        Log.d(TAG, "Returning null because of wrong redirect URI.");
-        return null;
-      }
-      Log.i(TAG, "Param URI redirect to " + redirectUri);
-      uri = redirectUri;
-    } finally {
-      connection.disconnect();
-    }
-    return uri;
-  }
 }

--- a/sdk/qrcode/ios/qr_code.mm
+++ b/sdk/qrcode/ios/qr_code.mm
@@ -97,6 +97,9 @@ void scanQrCodeAndSaveDeviceParams() {
   }
 }
 
+// TODO(arilow): Implementation needed. See qr_code.cc
+void saveDeviceParams(const uint8_t* uri, int size){}
+
 int getQrCodeScanCount() { return qrCodeScanCount; }
 
 }  // namespace qrcode


### PR DESCRIPTION
Hello gentlemen! I am working on the implementation of a couple of functions to set and save the device param of the headset by passing only the URI.

But before going any further I wanted to ask what do you think about this API proposal. Or how can I improve it.
 
My idea is to create a function in `CardboardParamsUtils` on the Java side that receives the URI as a byte array and the context (it will be called from `setAndSaveDeviceParams()` ). This function should call `createFromUri()` and `writeDeviceParams()` to write the device parameters in the storage. 

Then we will need to reload the app to make the changes visible. And here is a question: Do you think this is something to do in the same function? or it should be done from outside?

Please tell me your thoughts and give me as many corrections as it is needed to make it work properly.

Looking forward to hear your thoughts,
Ariel
