### PR TITLE
multiple orientation support

### DIFF
--- a/hellocardboard-android/src/main/jni/hello_cardboard_app.cc
+++ b/hellocardboard-android/src/main/jni/hello_cardboard_app.cc
@@ -365,7 +365,8 @@ Matrix4x4 HelloCardboardApp::GetPose() {
   std::array<float, 3> out_position;
   long monotonic_time_nano = GetMonotonicTimeNano();
   monotonic_time_nano += kPredictionTimeWithoutVsyncNanos;
-  CardboardHeadTracker_getPose(head_tracker_, monotonic_time_nano,
+  CardboardHeadTracker_getPose(head_tracker_,monotonic_time_nano,
+                               CardboardViewportOrientation_LandscapeLeft,
                                &out_position[0], &out_orientation[0]);
   return GetTranslationMatrix(out_position) *
          Quatf::FromXYZW(&out_orientation[0]).ToMatrix();

--- a/hellocardboard-android/src/main/jni/hello_cardboard_app.cc
+++ b/hellocardboard-android/src/main/jni/hello_cardboard_app.cc
@@ -366,7 +366,7 @@ Matrix4x4 HelloCardboardApp::GetPose() {
   long monotonic_time_nano = GetMonotonicTimeNano();
   monotonic_time_nano += kPredictionTimeWithoutVsyncNanos;
   CardboardHeadTracker_getPose(head_tracker_,monotonic_time_nano,
-                               kCardboardViewportOrientationLandscapeLeft,
+                               kLandscapeLeft,
                                &out_position[0], &out_orientation[0]);
   return GetTranslationMatrix(out_position) *
          Quatf::FromXYZW(&out_orientation[0]).ToMatrix();

--- a/hellocardboard-android/src/main/jni/hello_cardboard_app.cc
+++ b/hellocardboard-android/src/main/jni/hello_cardboard_app.cc
@@ -366,7 +366,7 @@ Matrix4x4 HelloCardboardApp::GetPose() {
   long monotonic_time_nano = GetMonotonicTimeNano();
   monotonic_time_nano += kPredictionTimeWithoutVsyncNanos;
   CardboardHeadTracker_getPose(head_tracker_,monotonic_time_nano,
-                               CardboardViewportOrientation_LandscapeLeft,
+                               kCardboardViewportOrientationLandscapeLeft,
                                &out_position[0], &out_orientation[0]);
   return GetTranslationMatrix(out_position) *
          Quatf::FromXYZW(&out_orientation[0]).ToMatrix();

--- a/hellocardboard-ios/HelloCardboardRenderer.mm
+++ b/hellocardboard-ios/HelloCardboardRenderer.mm
@@ -197,8 +197,7 @@ void HelloCardboardRenderer::DrawFrame() {
   // Head tracker cardboard.
   float position[3];
   float orientation[4];
-  CardboardHeadTracker_getPose(_headTracker, targetTime,
-                            kLandscapeLeft, position, orientation);
+  CardboardHeadTracker_getPose(_headTracker, targetTime, kLandscapeLeft, position, orientation);
   _headView =
       GLKMatrix4Multiply(GLKMatrix4MakeTranslation(position[0], position[1], position[2]),
                          GLKMatrix4MakeWithQuaternion(GLKQuaternionMakeWithArray(orientation)));

--- a/hellocardboard-ios/HelloCardboardRenderer.mm
+++ b/hellocardboard-ios/HelloCardboardRenderer.mm
@@ -197,7 +197,8 @@ void HelloCardboardRenderer::DrawFrame() {
   // Head tracker cardboard.
   float position[3];
   float orientation[4];
-  CardboardHeadTracker_getPose(_headTracker, targetTime, position, orientation);
+  CardboardHeadTracker_getPose(_headTracker, targetTime,
+                            kLandscapeLeft, position, orientation);
   _headView =
       GLKMatrix4Multiply(GLKMatrix4MakeTranslation(position[0], position[1], position[2]),
                          GLKMatrix4MakeWithQuaternion(GLKQuaternionMakeWithArray(orientation)));

--- a/sdk/cardboard.cc
+++ b/sdk/cardboard.cc
@@ -27,7 +27,6 @@
 #include "util/is_initialized.h"
 #include "util/logging.h"
 #ifdef __ANDROID__
-
 #endif
 
 // TODO(b/134142617): Revisit struct/class hierarchy.

--- a/sdk/cardboard.cc
+++ b/sdk/cardboard.cc
@@ -28,6 +28,8 @@
 #include "util/logging.h"
 #ifdef __ANDROID__
 #include "device_params/android/device_params.h"
+#include "../hellocardboard-android/libraries/cardboard.h"
+
 #endif
 
 // TODO(b/134142617): Revisit struct/class hierarchy.
@@ -305,7 +307,9 @@ void CardboardHeadTracker_resume(CardboardHeadTracker* head_tracker) {
 }
 
 void CardboardHeadTracker_getPose(CardboardHeadTracker* head_tracker,
-                                  int64_t timestamp_ns, float* position,
+                                  int64_t timestamp_ns,
+                                  CardboardViewportOrientation viewport_orientation,
+                                  float* position,
                                   float* orientation) {
   if (CARDBOARD_IS_NOT_INITIALIZED() || CARDBOARD_IS_ARG_NULL(head_tracker) ||
       CARDBOARD_IS_ARG_NULL(position) || CARDBOARD_IS_ARG_NULL(orientation)) {
@@ -316,7 +320,8 @@ void CardboardHeadTracker_getPose(CardboardHeadTracker* head_tracker,
   std::array<float, 3> out_position;
   std::array<float, 4> out_orientation;
   static_cast<cardboard::HeadTracker*>(head_tracker)
-      ->GetPose(timestamp_ns, out_position, out_orientation);
+      ->GetPose(timestamp_ns, viewport_orientation,
+        out_position, out_orientation);
   std::memcpy(position, &out_position[0], 3 * sizeof(float));
   std::memcpy(orientation, &out_orientation[0], 4 * sizeof(float));
 }

--- a/sdk/cardboard.cc
+++ b/sdk/cardboard.cc
@@ -27,6 +27,7 @@
 #include "util/is_initialized.h"
 #include "util/logging.h"
 #ifdef __ANDROID__
+#include "device_params/android/device_params.h"
 #endif
 
 // TODO(b/134142617): Revisit struct/class hierarchy.

--- a/sdk/cardboard.cc
+++ b/sdk/cardboard.cc
@@ -27,8 +27,6 @@
 #include "util/is_initialized.h"
 #include "util/logging.h"
 #ifdef __ANDROID__
-#include "device_params/android/device_params.h"
-#include "../hellocardboard-android/libraries/cardboard.h"
 
 #endif
 

--- a/sdk/head_tracker.cc
+++ b/sdk/head_tracker.cc
@@ -63,6 +63,7 @@ void HeadTracker::Resume() {
 }
 
 void HeadTracker::GetPose(int64_t timestamp_ns,
+                          CardboardViewportOrientation viewport_orientation,
                           std::array<float, 3>& out_position,
                           std::array<float, 4>& out_orientation) const {
   Rotation predicted_rotation;

--- a/sdk/head_tracker.cc
+++ b/sdk/head_tracker.cc
@@ -25,39 +25,38 @@ namespace cardboard {
 namespace {
 
 void GetRotationsFromViewportOrientation(
-        const CardboardViewportOrientation Viewport_orientation,
-        Rotation* ekf_to_head_tracker,
-        Rotation* sensor_to_display) {
-
+    const CardboardViewportOrientation viewport_orientation,
+    Rotation* ekf_to_head_tracker, Rotation* sensor_to_display) {
   // This is the same than initializing the rotation from
   // Rotation::FromYawPitchRoll(-M_PI / 2., 0, -M_PI / 2.).
   static const Rotation kEkftoHeadTrackerLandscapeLeft =
-          Rotation::FromQuaternion(Rotation::QuaternionType(0.5, -0.5, -0.5, 0.5));
+      Rotation::FromQuaternion(Rotation::QuaternionType(0.5, -0.5, -0.5, 0.5));
   static const Rotation kSensorToDisplayLandscapeLeft =
-          Rotation::FromAxisAndAngle(Vector3(0., 0., 1.), M_PI / 2.);
+      Rotation::FromAxisAndAngle(Vector3(0., 0., 1.), M_PI / 2.);
 
   // This is the same than initializing the rotation from
   // Rotation::FromYawPitchRoll(M_PI / 2., 0, M_PI / 2.).
   static const Rotation kEkftoHeadTrackerLandscapeRight =
-          Rotation::FromQuaternion(Rotation::QuaternionType(0.5, 0.5, 0.5, 0.5));
+      Rotation::FromQuaternion(Rotation::QuaternionType(0.5, 0.5, 0.5, 0.5));
   static const Rotation kSensorToDisplayLandscapeRight =
-          Rotation::FromAxisAndAngle(Vector3(0., 0., 1.), -M_PI / 2.);
+      Rotation::FromAxisAndAngle(Vector3(0., 0., 1.), -M_PI / 2.);
 
   // This is the same than initializing the rotation from
   // Rotation::FromYawPitchRoll(M_PI / 2., M_PI / 2., M_PI / 2.).
-  static const Rotation kEkftoHeadTrackerPortrait =
-          Rotation::FromQuaternion(Rotation::QuaternionType(0.707107, 0, 0, 0.707107));
+  static const Rotation kEkftoHeadTrackerPortrait = Rotation::FromQuaternion(
+      Rotation::QuaternionType(0.7071067811865476, 0., 0., 0.7071067811865476));
   static const Rotation kSensorToDisplayPortrait =
-          Rotation::FromAxisAndAngle(Vector3(0., 0., 1.), 0.);
+      Rotation::FromAxisAndAngle(Vector3(0., 0., 1.), 0.);
 
   // This is the same than initializing the rotation from
   // Rotation::FromYawPitchRoll(-M_PI / 2., -M_PI / 2., -M_PI / 2.).
   static const Rotation kEkftoHeadTrackerPortraitUpsideDown =
-          Rotation::FromQuaternion(Rotation::QuaternionType(0, -0.707107, -0.707107, 0));
+      Rotation::FromQuaternion(Rotation::QuaternionType(
+          0., -0.7071067811865476, -0.7071067811865476, 0.));
   static const Rotation kSensorToDisplayPortraitUpsideDown =
-          Rotation::FromAxisAndAngle(Vector3(0., 0., 1.), M_PI);
+      Rotation::FromAxisAndAngle(Vector3(0., 0., 1.), M_PI);
 
-  switch (Viewport_orientation) {
+  switch (viewport_orientation) {
     case kLandscapeLeft:
       *ekf_to_head_tracker = kEkftoHeadTrackerLandscapeLeft;
       *sensor_to_display = kSensorToDisplayLandscapeLeft;
@@ -145,7 +144,7 @@ void HeadTracker::GetPose(int64_t timestamp_ns,
   Rotation ekf_to_head_tracker;
   Rotation sensor_to_display;
   GetRotationsFromViewportOrientation(viewport_orientation,
-                        &ekf_to_head_tracker, &sensor_to_display);
+                                      &ekf_to_head_tracker, &sensor_to_display);
 
   const Vector4 q =
       (sensor_to_display * predicted_rotation * ekf_to_head_tracker)

--- a/sdk/head_tracker.cc
+++ b/sdk/head_tracker.cc
@@ -24,7 +24,7 @@
 namespace cardboard {
 namespace {
 
-void GetViewportOrientationRotation(
+void GetRotationsFromViewportOrientation(
         const CardboardViewportOrientation Viewport_orientation,
         Rotation* ekf_to_head_tracker,
         Rotation* sensor_to_display) {
@@ -79,6 +79,7 @@ void GetViewportOrientationRotation(
       break;
 
     default:
+      break;
   }
 }
 
@@ -143,7 +144,7 @@ void HeadTracker::GetPose(int64_t timestamp_ns,
   // space.
   Rotation ekf_to_head_tracker;
   Rotation sensor_to_display;
-  GetViewportOrientationRotation(viewport_orientation,
+  GetRotationsFromViewportOrientation(viewport_orientation,
                         &ekf_to_head_tracker, &sensor_to_display);
 
   const Vector4 q =

--- a/sdk/head_tracker.cc
+++ b/sdk/head_tracker.cc
@@ -24,8 +24,8 @@
 namespace cardboard {
 namespace {
 
-void GetViewporOrientationRotation(
-        const CardboardViewportOrientation ViewportOrientation,
+void GetViewportOrientationRotation(
+        const CardboardViewportOrientation Viewport_orientation,
         Rotation* ekf_to_head_tracker,
         Rotation* sensor_to_display) {
 
@@ -34,49 +34,51 @@ void GetViewporOrientationRotation(
   static const Rotation kEkftoHeadTrackerLandscapeLeft =
           Rotation::FromQuaternion(Rotation::QuaternionType(0.5, -0.5, -0.5, 0.5));
   static const Rotation kSensorToDisplayLandscapeLeft =
-          Rotation::FromAxisAndAngle(Vector3(0, 0, 1), M_PI / 2.);
+          Rotation::FromAxisAndAngle(Vector3(0., 0., 1.), M_PI / 2.);
 
   // This is the same than initializing the rotation from
   // Rotation::FromYawPitchRoll(M_PI / 2., 0, M_PI / 2.).
   static const Rotation kEkftoHeadTrackerLandscapeRight =
           Rotation::FromQuaternion(Rotation::QuaternionType(0.5, 0.5, 0.5, 0.5));
   static const Rotation kSensorToDisplayLandscapeRight =
-          Rotation::FromAxisAndAngle(Vector3(0, 0, 1), -M_PI / 2.);
+          Rotation::FromAxisAndAngle(Vector3(0., 0., 1.), -M_PI / 2.);
 
   // This is the same than initializing the rotation from
   // Rotation::FromYawPitchRoll(M_PI / 2., M_PI / 2., M_PI / 2.).
   static const Rotation kEkftoHeadTrackerPortrait =
           Rotation::FromQuaternion(Rotation::QuaternionType(0.707107, 0, 0, 0.707107));
   static const Rotation kSensorToDisplayPortrait =
-          Rotation::FromAxisAndAngle(Vector3(0, 0, 1), 0.);
+          Rotation::FromAxisAndAngle(Vector3(0., 0., 1.), 0.);
 
   // This is the same than initializing the rotation from
   // Rotation::FromYawPitchRoll(-M_PI / 2., -M_PI / 2., -M_PI / 2.).
   static const Rotation kEkftoHeadTrackerPortraitUpsideDown =
           Rotation::FromQuaternion(Rotation::QuaternionType(0, -0.707107, -0.707107, 0));
   static const Rotation kSensorToDisplayPortraitUpsideDown =
-          Rotation::FromAxisAndAngle(Vector3(0, 0, 1), M_PI);
+          Rotation::FromAxisAndAngle(Vector3(0., 0., 1.), M_PI);
 
-  switch (ViewportOrientation) {
-    case kCardboardViewportOrientationLandscapeLeft:
+  switch (Viewport_orientation) {
+    case kLandscapeLeft:
       *ekf_to_head_tracker = kEkftoHeadTrackerLandscapeLeft;
-          *sensor_to_display = kSensorToDisplayLandscapeLeft;
-          break;
+      *sensor_to_display = kSensorToDisplayLandscapeLeft;
+      break;
 
-    case kCardboardViewportOrientationLandscapeRight:
+    case kLandscapeRight:
       *ekf_to_head_tracker = kEkftoHeadTrackerLandscapeRight;
-          *sensor_to_display = kSensorToDisplayLandscapeRight;
-          break;
+      *sensor_to_display = kSensorToDisplayLandscapeRight;
+      break;
 
-    case kCardboardViewportOrientationPortrait:
+    case kPortrait:
       *ekf_to_head_tracker = kEkftoHeadTrackerPortrait;
-          *sensor_to_display = kSensorToDisplayPortrait;
-          break;
+      *sensor_to_display = kSensorToDisplayPortrait;
+      break;
 
-    default: // PortraitUpsideDown
+    case kPortraitUpsideDown:
       *ekf_to_head_tracker = kEkftoHeadTrackerPortraitUpsideDown;
-          *sensor_to_display = kSensorToDisplayPortraitUpsideDown;
-          break;
+      *sensor_to_display = kSensorToDisplayPortraitUpsideDown;
+      break;
+
+    default:
   }
 }
 
@@ -141,7 +143,7 @@ void HeadTracker::GetPose(int64_t timestamp_ns,
   // space.
   Rotation ekf_to_head_tracker;
   Rotation sensor_to_display;
-  GetViewporOrientationRotation(viewport_orientation,
+  GetViewportOrientationRotation(viewport_orientation,
                         &ekf_to_head_tracker, &sensor_to_display);
 
   const Vector4 q =

--- a/sdk/head_tracker.h
+++ b/sdk/head_tracker.h
@@ -25,6 +25,7 @@
 #include "sensors/sensor_event_producer.h"
 #include "sensors/sensor_fusion_ekf.h"
 #include "util/rotation.h"
+#include "include/cardboard.h"
 
 namespace cardboard {
 
@@ -44,7 +45,8 @@ class HeadTracker {
 
   // Gets the predicted pose for a given timestamp.
   // TODO(b/135488467): Support different display to sensor orientations.
-  void GetPose(int64_t timestamp_ns, std::array<float, 3>& out_position,
+  void GetPose(int64_t timestamp_ns, CardboardViewportOrientation viewport_orientation,
+               std::array<float, 3>& out_position,
                std::array<float, 4>& out_orientation) const;
 
  private:

--- a/sdk/head_tracker.h
+++ b/sdk/head_tracker.h
@@ -44,7 +44,6 @@ class HeadTracker {
   void Resume();
 
   // Gets the predicted pose for a given timestamp.
-  // TODO(b/135488467): Support different display to sensor orientations.
   void GetPose(int64_t timestamp_ns, CardboardViewportOrientation viewport_orientation,
                std::array<float, 3>& out_position,
                std::array<float, 4>& out_orientation) const;

--- a/sdk/include/cardboard.h
+++ b/sdk/include/cardboard.h
@@ -42,6 +42,7 @@ typedef enum CardboardEye {
   kRight = 1,
 } CardboardEye;
 
+/// Enum to distinguish the possible orientation of the viewport
 typedef enum CardboardViewportOrientation {
   kCardboardViewportOrientationLandscapeLeft = 0,
   kCardboardViewportOrientationLandscapeRight = 1,

--- a/sdk/include/cardboard.h
+++ b/sdk/include/cardboard.h
@@ -42,6 +42,13 @@ typedef enum CardboardEye {
   kRight = 1,
 } CardboardEye;
 
+typedef enum CardboardViewportOrientation {
+  CardboardViewportOrientation_LandscapeLeft = 0,
+  CardboardViewportOrientation_LandscapeRight = 1,
+  CardboardViewportOrientation_Portrait = 2,
+  CardboardViewportOrientation_PortraitUpsideDown = 3,
+} CardboardViewportOrientation;
+
 /// Struct representing a 3D mesh with 3D vertices and corresponding UV
 /// coordinates.
 typedef struct CardboardMesh {
@@ -383,21 +390,28 @@ void CardboardHeadTracker_resume(CardboardHeadTracker* head_tracker);
 
 /// Gets the predicted head pose for a given timestamp.
 ///
+/// @details  @p viewport_orientation will incur in an extra rotation to the head rotation to
+///           align the pose with the viewport orientation. 
+///           CardboardViewportOrientation_LandscapeLeft introduces an identity rotation to the
+///           head tracker pose.
+///
 /// @pre @p head_tracker Must not be null.
 /// @pre @p position Must not be null.
 /// @pre @p orientation Must not be null.
+/// @pre @p viewport_orientation Must be a valid CardboardViewportOrientation.
 /// When it is unmet, a call to this function results in a no-op and default
 /// values are returned (zero values and identity quaternion, respectively).
 ///
 /// @param[in]      head_tracker            Head tracker object pointer.
 /// @param[in]      timestamp_ns            The timestamp for the pose in
-///     nanoseconds in system monotonic clock.
+///                                         nanoseconds.
+/// @param[in]      viewport_orientation    The viewport orientation.
 /// @param[out]     position                3 floats for (x, y, z).
 /// @param[out]     orientation             4 floats for quaternion
 void CardboardHeadTracker_getPose(CardboardHeadTracker* head_tracker,
-                                  int64_t timestamp_ns, float* position,
-                                  float* orientation);
-
+                                  int64_t timestamp_ns,
+                                  CardboardViewportOrientation viewport_orientation,
+                                  float* position, float* orientation);
 /// @}
 
 /////////////////////////////////////////////////////////////////////////////

--- a/sdk/include/cardboard.h
+++ b/sdk/include/cardboard.h
@@ -43,10 +43,10 @@ typedef enum CardboardEye {
 } CardboardEye;
 
 typedef enum CardboardViewportOrientation {
-  CardboardViewportOrientation_LandscapeLeft = 0,
-  CardboardViewportOrientation_LandscapeRight = 1,
-  CardboardViewportOrientation_Portrait = 2,
-  CardboardViewportOrientation_PortraitUpsideDown = 3,
+  kCardboardViewportOrientationLandscapeLeft = 0,
+  kCardboardViewportOrientationLandscapeRight = 1,
+  kCardboardViewportOrientationPortrait = 2,
+  kCardboardViewportOrientationPortraitUpsideDown = 3,
 } CardboardViewportOrientation;
 
 /// Struct representing a 3D mesh with 3D vertices and corresponding UV

--- a/sdk/include/cardboard.h
+++ b/sdk/include/cardboard.h
@@ -42,12 +42,16 @@ typedef enum CardboardEye {
   kRight = 1,
 } CardboardEye;
 
-/// Enum to distinguish the possible orientation of the viewport
+/// Enum to describe the possible orientation of the viewport.
 typedef enum CardboardViewportOrientation {
-  kCardboardViewportOrientationLandscapeLeft = 0,
-  kCardboardViewportOrientationLandscapeRight = 1,
-  kCardboardViewportOrientationPortrait = 2,
-  kCardboardViewportOrientationPortraitUpsideDown = 3,
+  /// Landscape left orientation.
+  kLandscapeLeft = 0,
+  /// Landscape right orientation.
+  kLandscapeRight = 1,
+  /// Portrait orientation.
+  kPortrait = 2,
+  /// Portrait upside down orientation.
+  kPortraitUpsideDown = 3,
 } CardboardViewportOrientation;
 
 /// Struct representing a 3D mesh with 3D vertices and corresponding UV
@@ -393,13 +397,11 @@ void CardboardHeadTracker_resume(CardboardHeadTracker* head_tracker);
 ///
 /// @details  @p viewport_orientation will incur in an extra rotation to the head rotation to
 ///           align the pose with the viewport orientation. 
-///           CardboardViewportOrientation_LandscapeLeft introduces an identity rotation to the
-///           head tracker pose.
+///           kLandscapeLeft introduces an identity rotation to the head tracker pose.
 ///
 /// @pre @p head_tracker Must not be null.
 /// @pre @p position Must not be null.
 /// @pre @p orientation Must not be null.
-/// @pre @p viewport_orientation Must be a valid CardboardViewportOrientation.
 /// When it is unmet, a call to this function results in a no-op and default
 /// values are returned (zero values and identity quaternion, respectively).
 ///

--- a/sdk/unity/xr_provider/input.cc
+++ b/sdk/unity/xr_provider/input.cc
@@ -128,7 +128,8 @@ class CardboardInputProvider {
   UnitySubsystemErrorCode Tick() {
     std::array<float, 4> out_orientation;
     std::array<float, 3> out_position;
-    cardboard_api_->GetHeadTrackerPose(out_position.data(), out_orientation.data());
+    cardboard_api_->GetHeadTrackerPose(out_position.data(), 
+                                       out_orientation.data());
     // TODO(b/151817737): Compute pose position within SDK with custom rotation.
     head_pose_ = cardboard::unity::CardboardRotationToUnityPose(out_orientation);
     return kUnitySubsystemErrorCodeSuccess;

--- a/sdk/unity/xr_provider/input.cc
+++ b/sdk/unity/xr_provider/input.cc
@@ -128,7 +128,7 @@ class CardboardInputProvider {
   UnitySubsystemErrorCode Tick() {
     std::array<float, 4> out_orientation;
     std::array<float, 3> out_position;
-    cardboard_api_->GetHeadTrackerPose(CardboardViewportOrientation_LandscapeLeft,
+    cardboard_api_->GetHeadTrackerPose(kCardboardViewportOrientationLandscapeLeft,
                                        out_position.data(),
                                        out_orientation.data());
     // TODO(b/151817737): Compute pose position within SDK with custom rotation.

--- a/sdk/unity/xr_provider/input.cc
+++ b/sdk/unity/xr_provider/input.cc
@@ -128,9 +128,7 @@ class CardboardInputProvider {
   UnitySubsystemErrorCode Tick() {
     std::array<float, 4> out_orientation;
     std::array<float, 3> out_position;
-    cardboard_api_->GetHeadTrackerPose(kCardboardViewportOrientationLandscapeLeft,
-                                       out_position.data(),
-                                       out_orientation.data());
+    cardboard_api_->GetHeadTrackerPose(out_position.data(), out_orientation.data());
     // TODO(b/151817737): Compute pose position within SDK with custom rotation.
     head_pose_ = cardboard::unity::CardboardRotationToUnityPose(out_orientation);
     return kUnitySubsystemErrorCodeSuccess;

--- a/sdk/unity/xr_provider/input.cc
+++ b/sdk/unity/xr_provider/input.cc
@@ -128,7 +128,8 @@ class CardboardInputProvider {
   UnitySubsystemErrorCode Tick() {
     std::array<float, 4> out_orientation;
     std::array<float, 3> out_position;
-    cardboard_api_->GetHeadTrackerPose(out_position.data(),
+    cardboard_api_->GetHeadTrackerPose(CardboardViewportOrientation_LandscapeLeft,
+                                       out_position.data(),
                                        out_orientation.data());
     // TODO(b/151817737): Compute pose position within SDK with custom rotation.
     head_pose_ = cardboard::unity::CardboardRotationToUnityPose(out_orientation);

--- a/sdk/unity/xr_unity_plugin/cardboard_xr_unity.cc
+++ b/sdk/unity/xr_unity_plugin/cardboard_xr_unity.cc
@@ -709,9 +709,9 @@ void CardboardApi::PauseHeadTracker() { p_impl_->PauseHeadTracker(); }
 
 void CardboardApi::ResumeHeadTracker() { p_impl_->ResumeHeadTracker(); }
 
-void CardboardApi::GetHeadTrackerPose(CardboardViewportOrientation viewportOrientation,
+void CardboardApi::GetHeadTrackerPose(CardboardViewportOrientation viewport_orientation,
                                       float* position, float* orientation) {
-  p_impl_->GetHeadTrackerPose(viewportOrientation, position, orientation);
+  p_impl_->GetHeadTrackerPose(viewport_orientation, position, orientation);
 }
 
 void CardboardApi::ScanDeviceParams() { CardboardApiImpl::ScanDeviceParams(); }

--- a/sdk/unity/xr_unity_plugin/cardboard_xr_unity.cc
+++ b/sdk/unity/xr_unity_plugin/cardboard_xr_unity.cc
@@ -273,6 +273,7 @@ class CardboardApi::CardboardApiImpl {
     CardboardHeadTracker_getPose(head_tracker_.get(),
                                  CardboardApiImpl::GetMonotonicTimeNano() +
                                      kPredictionTimeWithoutVsyncNanos,
+                                 CardboardViewportOrientation_LandscapeLeft,
                                  position, orientation);
   }
 

--- a/sdk/unity/xr_unity_plugin/cardboard_xr_unity.cc
+++ b/sdk/unity/xr_unity_plugin/cardboard_xr_unity.cc
@@ -709,9 +709,9 @@ void CardboardApi::PauseHeadTracker() { p_impl_->PauseHeadTracker(); }
 
 void CardboardApi::ResumeHeadTracker() { p_impl_->ResumeHeadTracker(); }
 
-void CardboardApi::GetHeadTrackerPose(CardboardViewportOrientation viewport_orientation,
-                                      float* position, float* orientation) {
-  p_impl_->GetHeadTrackerPose(viewport_orientation, position, orientation);
+void CardboardApi::GetHeadTrackerPose(float* position, float* orientation) {
+  p_impl_->GetHeadTrackerPose(kLandscapeLeft,
+                              position, orientation);
 }
 
 void CardboardApi::ScanDeviceParams() { CardboardApiImpl::ScanDeviceParams(); }

--- a/sdk/unity/xr_unity_plugin/cardboard_xr_unity.cc
+++ b/sdk/unity/xr_unity_plugin/cardboard_xr_unity.cc
@@ -258,7 +258,8 @@ class CardboardApi::CardboardApiImpl {
     CardboardHeadTracker_resume(head_tracker_.get());
   }
 
-  void GetHeadTrackerPose(float* position, float* orientation) {
+  void GetHeadTrackerPose(CardboardViewportOrientation viewportOrientation,
+                          float* position, float* orientation) {
     if (head_tracker_ == nullptr) {
       LOGW("Uninitialized head tracker was queried for the pose.");
       position[0] = 0.0f;
@@ -273,7 +274,7 @@ class CardboardApi::CardboardApiImpl {
     CardboardHeadTracker_getPose(head_tracker_.get(),
                                  CardboardApiImpl::GetMonotonicTimeNano() +
                                      kPredictionTimeWithoutVsyncNanos,
-                                 CardboardViewportOrientation_LandscapeLeft,
+                                 viewportOrientation,
                                  position, orientation);
   }
 
@@ -708,8 +709,9 @@ void CardboardApi::PauseHeadTracker() { p_impl_->PauseHeadTracker(); }
 
 void CardboardApi::ResumeHeadTracker() { p_impl_->ResumeHeadTracker(); }
 
-void CardboardApi::GetHeadTrackerPose(float* position, float* orientation) {
-  p_impl_->GetHeadTrackerPose(position, orientation);
+void CardboardApi::GetHeadTrackerPose(CardboardViewportOrientation viewportOrientation,
+                                      float* position, float* orientation) {
+  p_impl_->GetHeadTrackerPose(viewportOrientation, position, orientation);
 }
 
 void CardboardApi::ScanDeviceParams() { CardboardApiImpl::ScanDeviceParams(); }

--- a/sdk/unity/xr_unity_plugin/cardboard_xr_unity.h
+++ b/sdk/unity/xr_unity_plugin/cardboard_xr_unity.h
@@ -83,7 +83,7 @@ class CardboardApi {
   /// @param[out] orientation A pointer to an array with four floats to fill in
   ///             the quaternion that denotes the orientation of the head.
   // TODO(b/154305848): Move argument types to std::array*.
-  void GetHeadTrackerPose(CardboardViewportOrientation viewportOrientation,
+  void GetHeadTrackerPose(CardboardViewportOrientation viewport_orientation,
                           float* position, float* orientation);
 
   /// @brief Triggers a device parameters scan.

--- a/sdk/unity/xr_unity_plugin/cardboard_xr_unity.h
+++ b/sdk/unity/xr_unity_plugin/cardboard_xr_unity.h
@@ -17,6 +17,7 @@
 #define CARDBOARD_SDK_UNITY_XR_UNITY_PLUGIN_CARDBOARD_XR_UNITY_H_
 
 #include <memory>
+#include "include/cardboard.h"
 
 /// @brief Determines the supported graphics APIs.
 typedef enum CardboardGraphicsApi {
@@ -82,7 +83,8 @@ class CardboardApi {
   /// @param[out] orientation A pointer to an array with four floats to fill in
   ///             the quaternion that denotes the orientation of the head.
   // TODO(b/154305848): Move argument types to std::array*.
-  void GetHeadTrackerPose(float* position, float* orientation);
+  void GetHeadTrackerPose(CardboardViewportOrientation viewportOrientation,
+                          float* position, float* orientation);
 
   /// @brief Triggers a device parameters scan.
   /// @pre When using Android, the pointer to `JavaVM` must be previously set.

--- a/sdk/unity/xr_unity_plugin/cardboard_xr_unity.h
+++ b/sdk/unity/xr_unity_plugin/cardboard_xr_unity.h
@@ -17,7 +17,6 @@
 #define CARDBOARD_SDK_UNITY_XR_UNITY_PLUGIN_CARDBOARD_XR_UNITY_H_
 
 #include <memory>
-#include "include/cardboard.h"
 
 /// @brief Determines the supported graphics APIs.
 typedef enum CardboardGraphicsApi {
@@ -83,8 +82,9 @@ class CardboardApi {
   /// @param[out] orientation A pointer to an array with four floats to fill in
   ///             the quaternion that denotes the orientation of the head.
   // TODO(b/154305848): Move argument types to std::array*.
-  void GetHeadTrackerPose(CardboardViewportOrientation viewport_orientation,
-                          float* position, float* orientation);
+  // TODO(arilow): Support different display to sensor orientations
+  //  for Unity.
+  void GetHeadTrackerPose(float* position, float* orientation);
 
   /// @brief Triggers a device parameters scan.
   /// @pre When using Android, the pointer to `JavaVM` must be previously set.

--- a/sdk/unity/xr_unity_plugin/cardboard_xr_unity.h
+++ b/sdk/unity/xr_unity_plugin/cardboard_xr_unity.h
@@ -82,7 +82,7 @@ class CardboardApi {
   /// @param[out] orientation A pointer to an array with four floats to fill in
   ///             the quaternion that denotes the orientation of the head.
   // TODO(b/154305848): Move argument types to std::array*.
-  // TODO(arilow): Support different display to sensor orientations
+  // TODO(b/135488467): Support different display to sensor orientations
   //  for Unity.
   void GetHeadTrackerPose(float* position, float* orientation);
 


### PR DESCRIPTION
Hello Gentlemen. Following, this PR: https://github.com/googlevr/cardboard/pull/208 and this public document: https://docs.google.com/document/d/1ijyL0wXe7XHn1p2YP_bW8Ziaacy7Eto9ZAloPbHokzs/edit?pli=1

I made an implementation to support multiple orientation for the device. I had to make more changes than expected because I also changed the functions that call `CardboardHeadTracker_getPose()` accordingly (I think). 

Also I had to include "include/cardboard.h" in two header files because the `CardboardViewportOrientation` enum is in the function definition. Please pay special attention to this. You probably can find a better way of doing it.

Thanks in advance for reading,
Ariel