### PR TITLE
Fix Metal validation error for debug builds in Unity

### DIFF
--- a/sdk/unity/xr_unity_plugin/metal_renderer.mm
+++ b/sdk/unity/xr_unity_plugin/metal_renderer.mm
@@ -360,7 +360,7 @@ CardboardDistortionRenderer* MakeCardboardMetalDistortionRenderer(IUnityInterfac
   IUnityGraphicsMetalV1* metal_interface = xr_interfaces->Get<IUnityGraphicsMetalV1>();
   const CardboardMetalDistortionRendererConfig config{
       reinterpret_cast<uint64_t>(CFBridgingRetain(metal_interface->MetalDevice())),
-      MTLPixelFormatRGBA8Unorm, MTLPixelFormatDepth32Float_Stencil8,
+      MTLPixelFormatBGRA8Unorm, MTLPixelFormatDepth32Float_Stencil8,
       MTLPixelFormatDepth32Float_Stencil8};
 
   CardboardDistortionRenderer* distortion_renderer =


### PR DESCRIPTION
Fixes #309 

This PR simply makes the test projects I have at hand work without visual error nor crashing.

I do not understand the original reason why this colour format was created different than the other buffer.
Someone who understands that reason needs to review this to know if this PR is safe or not.