### PR TITLE
Support Unity Input System Package

### DIFF
--- a/sdk/unity/xr_provider/input.cc
+++ b/sdk/unity/xr_provider/input.cc
@@ -75,7 +75,7 @@ class CardboardInputProvider {
                                     unsigned int) {
       CARDBOARD_INPUT_XR_TRACE_LOG(cardboard_input_provider_->GetTrace(),
                                    "No events to handle");
-      return kUnitySubsystemErrorCodeSuccess;
+      return kUnitySubsystemErrorCodeFailure;
     };
     input_provider.QueryTrackingOriginMode =
         [](UnitySubsystemHandle, void*,


### PR DESCRIPTION
It turns out to be remarkably simple to support the Input System package (a.k.a. New Input System)! 🥳 

This should address #230.

By returning `kUnitySubsystemErrorCodeSuccess` in the `HandleEvent` callback, the plugin was essentially responding to every event as "handled." This blocks default event handlers from handling events for device connected and disconnected, which resulted in the input system package ignoring HMD events. Simply returning `kUnitySubsystemErrorCodeFailure` fixes the issue. The [latest documentation](https://docs.unity3d.com/Manual/xrsdk-input.html) for `HandleEvent` explains:

> If the provider does not understand that event, it must return kUnitySubsystemErrorCodeFailure

This change is all that is needed to get HMD tracking working with the new `TrackedPoseDriver` and generic `XRHMD` device layout. I've also opened a [companion PR](https://github.com/googlevr/cardboard-xr-plugin/pull/24) to this one which also adds the `InputLayoutLoader` class described in the documentation linked above which adds a specific device layout for CardboardHMD. This PR also includes builds of the plugin with this fix applied.