### PR TITLE
Build sdk for x86 and x86_64 ABIs too

### DIFF
--- a/.github/workflows/Android-CI.yml
+++ b/.github/workflows/Android-CI.yml
@@ -11,6 +11,10 @@ jobs:
         uses: actions/checkout@v2.3.2
         with:
           fetch-depth: 0
+      - name: Set Up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
       - name: Build sdk
         run: ./gradlew :sdk:assemble
       - name: Build HelloCardboard

--- a/hellocardboard-android/build.gradle
+++ b/hellocardboard-android/build.gradle
@@ -21,7 +21,7 @@ android {
         versionName "1.20.0"
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         ndk {
-            abiFilters 'armeabi-v7a', 'arm64-v8a'
+            // abiFilters 'armeabi-v7a', 'arm64-v8a'
         }
         externalNativeBuild.cmake {
             arguments "-DANDROID_STL=c++_shared"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -21,7 +21,7 @@ android {
         versionName "1.20.0"
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         ndk {
-            abiFilters 'armeabi-v7a', 'arm64-v8a'
+            // abiFilters 'armeabi-v7a', 'arm64-v8a'
         }
         externalNativeBuild.cmake {
             arguments "-DANDROID_STL=c++_static"


### PR DESCRIPTION
- Since this https://github.com/googlevr/cardboard/issues/13 is long solved and x86 are needed for running faster emulator (testing), why not build those ABIs too ?
- Google now enforces x86 images to be run latest android version avds
- Also otherwise for larger compatibility.