### PR TITLE
Prevent undefined behavior in getSavedDeviceParams

### DIFF
--- a/sdk/cardboard.cc
+++ b/sdk/cardboard.cc
@@ -323,6 +323,10 @@ void CardboardQrCode_getSavedDeviceParams(uint8_t** encoded_device_params,
   }
   std::vector<uint8_t> device_params =
       cardboard::qrcode::getCurrentSavedDeviceParams();
+  if (device_params.size() == 0) {
+    GetDefaultEncodedDeviceParams(encoded_device_params, size);
+    return;
+  }
   *size = static_cast<int>(device_params.size());
   *encoded_device_params = new uint8_t[*size];
   memcpy(*encoded_device_params, &device_params[0], *size);


### PR DESCRIPTION
If there are no save device parameters then calling cardboard::qrcode::getCurrentSavedDeviceParams() will return a std::vector of length zero. Immediately following that call the 0th element of the vector is passed to memcpy.

Indexing into a std::vector of zero length results in undefined behavior. In the implementation of std::vector used by Chrome, for example, it triggers an assert. This patch checks to see if the data length is zero and falls back to returning the default parameters if so to avoid triggering any undefined behaviors.