### PR TITLE
Gyroscope Bias Estimation - Unnecessary Max Operation

### DIFF
--- a/sdk/sensors/gyroscope_bias_estimator.cc
+++ b/sdk/sensors/gyroscope_bias_estimator.cc
@@ -264,8 +264,8 @@ bool GyroscopeBiasEstimator::UpdateGyroscopeBias(
     return false;
   }
 
-  float update_weight = std::max(
-      0.0f, 1.0f - gyroscope_sample_norm2 / kGyroscopeForBiasThreshold);
+  float update_weight =
+      1.0f - gyroscope_sample_norm2 / kGyroscopeForBiasThreshold;
   update_weight *= update_weight;
   gyroscope_bias_lowpass_filter_.AddWeightedSample(
       gyroscope_lowpass_filter_.GetFilteredData(), timestamp_ns, update_weight);


### PR DESCRIPTION
**Summary**
This pull request removes an unnecessary `std::max` operation in the gyroscope bias estimation code. This improves code readability and efficiency without impacting the functionality of the algorithm.

**Description**
The targeted code block checks if the gyroscope sample's norm exceeds a threshold (`kGyroscopeForBiasThreshold`). If it does, the function exits early; otherwise, it computes an update weight.

Here is the code block:

```cpp
  if (gyroscope_sample_norm2 >= kGyroscopeForBiasThreshold) {
    return false;
  }

  float update_weight = std::max(
      0.0f, 1.0f - gyroscope_sample_norm2 / kGyroscopeForBiasThreshold);
  update_weight *= update_weight;
```
For the `std::max` operation to pick `0.0f` over `1.0f - gyroscope_sample_norm2 / kGyroscopeForBiasThreshold`, we need

```
0 >= 1 - gyroscope_sample_norm2 / kGyroscopeForBiasThreshold
```

which implies that

```
gyroscope_sample_norm2 >= kGyroscopeForBiasThreshold
```

However, this cannot occur due to the previous if-statement `if (gyroscope_sample_norm2 >= kGyroscopeForBiasThreshold)`, which would exit the function before reaching this point.

This suggests that the max operation is unnecessary here and can be omitted for code readability and efficiency.