### PR TITLE
Use cardboard_api.lds to limit exports

### DIFF
--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -112,3 +112,16 @@ target_link_libraries(GfxPluginCardboard
     # is not needed
     dl
 )
+
+set_property(
+    TARGET GfxPluginCardboard
+    APPEND_STRING
+    PROPERTY
+        LINK_FLAGS
+        " -Wl,--version-script=\"${CMAKE_CURRENT_SOURCE_DIR}/cardboard_api.lds\""
+)
+set_property(
+    TARGET GfxPluginCardboard
+    APPEND
+    PROPERTY LINK_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/cardboard_api.lds"
+)


### PR DESCRIPTION
There is an ld script in the repo to restrict exports from the SDK library, but the CMake build wasn't using it. It was pretty easy to add and greatly reduced the symbols exposed by the SDK library.