### PR TITLE
CMake Cleanup

### DIFF
--- a/hellocardboard-android/CMakeLists.txt
+++ b/hellocardboard-android/CMakeLists.txt
@@ -28,17 +28,20 @@ find_library(LOG_LIB log)
 
 set(libs_dir ${CMAKE_CURRENT_SOURCE_DIR}/libraries)
 
+set(CARDBOARD_LIB ${libs_dir}/jni/${ANDROID_ABI}/libGfxPluginCardboard.so)
+set(CARDBOARD_INCLUDE_DIR ${libs_dir})
+
 # === Cardboard Sample ===
 # Sources
 file(GLOB native_srcs "src/main/jni/*.cc")
 # Output binary
 add_library(cardboard_jni SHARED ${native_srcs})
 # Includes
-target_include_directories(cardboard_jni PRIVATE ${libs_dir})
+target_include_directories(cardboard_jni PRIVATE ${CARDBOARD_INCLUDE_DIR})
 # Build
 target_link_libraries(cardboard_jni
     ${ANDROID_LIB}
     ${GLESv2_LIB}
     ${GLESv3_LIB}
     ${LOG_LIB}
-    ${libs_dir}/jni/${ANDROID_ABI}/libGfxPluginCardboard.so)
+    ${CARDBOARD_LIB})

--- a/hellocardboard-android/CMakeLists.txt
+++ b/hellocardboard-android/CMakeLists.txt
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.4.1)
+cmake_minimum_required(VERSION 3.22.1)
+project(hellocardboard_android VERSION 1.0.0 LANGUAGES CXX)
 
 # C++ flags.
 set(CMAKE_CXX_STANDARD 17)

--- a/hellocardboard-android/CMakeLists.txt
+++ b/hellocardboard-android/CMakeLists.txt
@@ -21,10 +21,10 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 add_compile_options(-Wall -Wextra)
 
 # Standard Android dependencies
-find_library(android-lib android)
-find_library(GLESv2-lib GLESv2)
-find_library(GLESv3-lib GLESv3)
-find_library(log-lib log)
+find_library(ANDROID_LIB android)
+find_library(GLESv2_LIB GLESv2)
+find_library(GLESv3_LIB GLESv3)
+find_library(LOG_LIB log)
 
 set(libs_dir ${CMAKE_CURRENT_SOURCE_DIR}/libraries)
 
@@ -37,8 +37,8 @@ add_library(cardboard_jni SHARED ${native_srcs})
 target_include_directories(cardboard_jni PRIVATE ${libs_dir})
 # Build
 target_link_libraries(cardboard_jni
-    ${android-lib}
-    ${GLESv2-lib}
-    ${GLESv3-lib}
-    ${log-lib}
+    ${ANDROID_LIB}
+    ${GLESv2_LIB}
+    ${GLESv3_LIB}
+    ${LOG_LIB}
     ${libs_dir}/jni/${ANDROID_ABI}/libGfxPluginCardboard.so)

--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.4.1)
+cmake_minimum_required(VERSION 3.22.1)
+project(cardboard_sdk VERSION 1.0.0 LANGUAGES CXX)
 
 # C++ flags.
 set(CMAKE_CXX_STANDARD 17)
@@ -101,6 +102,7 @@ add_definitions(-DVK_USE_PLATFORM_ANDROID_KHR=1)
 
 # Build
 target_link_libraries(GfxPluginCardboard
+    PUBLIC
     ${android-lib}
     ${GLESv2-lib}
     # #gles3 - Library is only needed if OpenGL ES 3.0 support is desired.

--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -20,6 +20,11 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 add_compile_options(-Wall -Wextra)
 
+# If these are already defined, the existing value is used, rather then the default here.
+option(CARDBOARDSDK_RENDERING_GLESv3 "Enable rendering with GLESv3" ON)
+option(CARDBOARDSDK_RENDERING_VULKAN "Enable rendering with Vulkan" ON)
+option(CARDBOARDSDK_UNITY_PLUGIN "Enable use as a Unity plugin" ON)
+
 # Standard Android dependencies
 find_library(ANDROID_LIB android)
 find_library(GLESv2_LIB GLESv2)
@@ -27,7 +32,9 @@ find_library(LOG_LIB log)
 
 # #gles3 - Library is only needed if OpenGL ES 3.0 support is desired. Remove
 # the following line if OpenGL ES 3.0 support is not needed.
-find_library(GLESv3_LIB GLESv3)
+if(CARDBOARDSDK_RENDERING_GLESv3)
+    find_library(GLESv3_LIB GLESv3)
+endif()
 
 include_directories(.)
 
@@ -51,22 +58,27 @@ file(GLOB screen_params_srcs "screen_params/android/*.cc")
 file(GLOB device_params_srcs "device_params/android/*.cc")
 # Rendering Sources
 file(GLOB rendering_opengl_srcs "rendering/opengl_*.cc")
-# #vulkan This is required for Vulkan rendering. Remove the following two lines
-# if Vulkan rendering is not needed.
-file(GLOB rendering_vulkan_srcs "rendering/android/*.cc")
-file(GLOB rendering_vulkan_wrapper_srcs "rendering/android/vulkan/*.cc")
 
-# === Cardboard Unity JNI ===
-file(GLOB cardboard_unity_jni_srcs "unity/android/*.cc")
+if(CARDBOARDSDK_RENDERING_VULKAN)
+    # #vulkan This is required for Vulkan rendering. Remove the following two lines
+    # if Vulkan rendering is not needed.
+    file(GLOB rendering_vulkan_srcs "rendering/android/*.cc")
+    file(GLOB rendering_vulkan_wrapper_srcs "rendering/android/vulkan/*.cc")
+endif()
 
-# === Cardboard Unity Wrapper ===
-file(GLOB cardboard_xr_unity_srcs
-  "unity/xr_unity_plugin/*.cc"
-  "unity/xr_unity_plugin/vulkan/*.cc"
-)
+if(CARDBOARDSDK_UNITY_PLUGIN)
+    # === Cardboard Unity JNI ===
+    file(GLOB cardboard_unity_jni_srcs "unity/android/*.cc")
 
-# === Cardboard XR Provider for Unity ===
-file(GLOB cardboard_xr_provider_srcs "unity/xr_provider/*.cc")
+    # === Cardboard Unity Wrapper ===
+    file(GLOB cardboard_xr_unity_srcs
+    "unity/xr_unity_plugin/*.cc"
+    "unity/xr_unity_plugin/vulkan/*.cc"
+    )
+
+    # === Cardboard XR Provider for Unity ===
+    file(GLOB cardboard_xr_provider_srcs "unity/xr_provider/*.cc")
+endif()
 
 # Output binary
 add_library(GfxPluginCardboard SHARED
@@ -92,25 +104,41 @@ add_library(GfxPluginCardboard SHARED
     # Cardboard XR Provider for Unity sources
     ${cardboard_xr_provider_srcs})
 
-# Includes
-target_include_directories(GfxPluginCardboard
-    PRIVATE ../third_party/unity_plugin_api)
+if(CARDBOARDSDK_UNITY_PLUGIN)
+    # Includes
+    target_include_directories(GfxPluginCardboard
+        PRIVATE ../third_party/unity_plugin_api)
+endif()
 
-# #vulkan This is required for Vulkan rendering. Remove the following line if
-# Vulkan rendering is not needed.
-add_definitions(-DVK_USE_PLATFORM_ANDROID_KHR=1)
+if(CARDBOARDSDK_RENDERING_VULKAN)
+    # #vulkan This is required for Vulkan rendering. Remove the following line if
+    # Vulkan rendering is not needed.
+    target_compile_definitions(GfxPluginCardboard PUBLIC VK_USE_PLATFORM_ANDROID_KHR=1)
+endif()
 
 # Build
 target_link_libraries(GfxPluginCardboard
     PUBLIC
     ${ANDROID_LIB}
     ${GLESv2_LIB}
-    # #gles3 - Library is only needed if OpenGL ES 3.0 support is desired.
-    # Remove the following line if OpenGL ES 3.0 support is not needed.
-    ${GLESv3_LIB}
     ${LOG_LIB}
-    # #vulkan - This is required for Vulkan rendering (it is required to load
-    # libvulkan.so at runtime). Remove the following line if Vulkan rendering
-    # is not needed
-    dl
 )
+
+if(CARDBOARDSDK_RENDERING_VULKAN)
+    target_link_libraries(GfxPluginCardboard
+        PUBLIC
+        # #vulkan - This is required for Vulkan rendering (it is required to load
+        # libvulkan.so at runtime). Remove the following line if Vulkan rendering
+        # is not needed
+        dl
+    )
+endif()
+
+if(CARDBOARDSDK_RENDERING_GLESv3)
+    target_link_libraries(GfxPluginCardboard
+        PUBLIC
+        # #gles3 - Library is only needed if OpenGL ES 3.0 support is desired.
+        # Remove the following line if OpenGL ES 3.0 support is not needed.
+        ${GLESv3_LIB}
+    )
+endif()

--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -21,13 +21,13 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 add_compile_options(-Wall -Wextra)
 
 # Standard Android dependencies
-find_library(android-lib android)
-find_library(GLESv2-lib GLESv2)
-find_library(log-lib log)
+find_library(ANDROID_LIB android)
+find_library(GLESv2_LIB GLESv2)
+find_library(LOG_LIB log)
 
 # #gles3 - Library is only needed if OpenGL ES 3.0 support is desired. Remove
 # the following line if OpenGL ES 3.0 support is not needed.
-find_library(GLESv3-lib GLESv3)
+find_library(GLESv3_LIB GLESv3)
 
 include_directories(.)
 
@@ -51,8 +51,8 @@ file(GLOB screen_params_srcs "screen_params/android/*.cc")
 file(GLOB device_params_srcs "device_params/android/*.cc")
 # Rendering Sources
 file(GLOB rendering_opengl_srcs "rendering/opengl_*.cc")
-# #vulkan This is required for Vulkan rendering. Remove the following two lines
-# if Vulkan rendering is not needed.
+# #vulkan This is required for Vulkan rendering. Remove the following two lines
+# if Vulkan rendering is not needed.
 file(GLOB rendering_vulkan_srcs "rendering/android/*.cc")
 file(GLOB rendering_vulkan_wrapper_srcs "rendering/android/vulkan/*.cc")
 
@@ -97,20 +97,20 @@ target_include_directories(GfxPluginCardboard
     PRIVATE ../third_party/unity_plugin_api)
 
 # #vulkan This is required for Vulkan rendering. Remove the following line if
-# Vulkan rendering is not needed.
+# Vulkan rendering is not needed.
 add_definitions(-DVK_USE_PLATFORM_ANDROID_KHR=1)
 
 # Build
 target_link_libraries(GfxPluginCardboard
     PUBLIC
-    ${android-lib}
-    ${GLESv2-lib}
+    ${ANDROID_LIB}
+    ${GLESv2_LIB}
     # #gles3 - Library is only needed if OpenGL ES 3.0 support is desired.
     # Remove the following line if OpenGL ES 3.0 support is not needed.
-    ${GLESv3-lib}
-    ${log-lib}
+    ${GLESv3_LIB}
+    ${LOG_LIB}
     # #vulkan - This is required for Vulkan rendering (it is required to load
     # libvulkan.so at runtime). Remove the following line if Vulkan rendering
-    # is not needed
+    # is not needed
     dl
 )


### PR DESCRIPTION
This fixes most of the errors building with a newer toolchain, etc.

(I still have to `./gradlew sdk:assembleRelease extractNdk` before trying to do anything with hellocardboard-android, but it does build and build nicely now.)

Additionally, I added CMake options to control the optional parts of the Cardboard SDK. This is likely to be appreciated by downstream users who can reduce their diff against the official SDK by just configuring these variables, instead of editing the CMake file.