### PR TITLE
Prefab

### DIFF
--- a/hellocardboard-android/CMakeLists.txt
+++ b/hellocardboard-android/CMakeLists.txt
@@ -26,22 +26,20 @@ find_library(GLESv2_LIB GLESv2)
 find_library(GLESv3_LIB GLESv3)
 find_library(LOG_LIB log)
 
-set(libs_dir ${CMAKE_CURRENT_SOURCE_DIR}/libraries)
+# Cardboard SDK prefab
+find_package(sdk REQUIRED CONFIG)
 
-set(CARDBOARD_LIB ${libs_dir}/jni/${ANDROID_ABI}/libGfxPluginCardboard.so)
-set(CARDBOARD_INCLUDE_DIR ${libs_dir})
 
 # === Cardboard Sample ===
 # Sources
 file(GLOB native_srcs "src/main/jni/*.cc")
 # Output binary
 add_library(cardboard_jni SHARED ${native_srcs})
-# Includes
-target_include_directories(cardboard_jni PRIVATE ${CARDBOARD_INCLUDE_DIR})
 # Build
 target_link_libraries(cardboard_jni
     ${ANDROID_LIB}
     ${GLESv2_LIB}
     ${GLESv3_LIB}
     ${LOG_LIB}
-    ${CARDBOARD_LIB})
+    # This also adds include directories
+    sdk::GfxPluginCardboard)

--- a/hellocardboard-android/CMakeLists.txt
+++ b/hellocardboard-android/CMakeLists.txt
@@ -28,17 +28,20 @@ find_library(LOG_LIB log)
 
 set(libs_dir ${CMAKE_CURRENT_SOURCE_DIR}/libraries)
 
+set(CARDBOARD_LIB ${libs_dir}/jni/${ANDROID_ABI}/libGfxPluginCardboard.so)
+set(CARDBOARD_INCLUDE_DIR ${libs_dir})
+
 # === Cardboard Sample ===
 # Sources
 file(GLOB native_srcs "src/main/jni/*.cc")
 # Output binary
 add_library(cardboard_jni SHARED ${native_srcs})
 # Includes
-target_include_directories(cardboard_jni PRIVATE ${libs_dir})
+target_include_directories(cardboard_jni PRIVATE ${CARDBOARD_INCLUDE_DIR})
 # Build
 target_link_libraries(cardboard_jni
     ${ANDROID_LIB}
     ${GLESv2_LIB}
     ${GLESv3_LIB}
     ${LOG_LIB}
-    ${libs_dir}/jni/${ANDROID_ABI}/libGfxPluginCardboard.so)
+    ${CARDBOARD_LIB})

--- a/hellocardboard-android/CMakeLists.txt
+++ b/hellocardboard-android/CMakeLists.txt
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.4.1)
+cmake_minimum_required(VERSION 3.22.1)
+project(hellocardboard_android VERSION 1.0.0 LANGUAGES CXX)
 
 # C++ flags.
 set(CMAKE_CXX_STANDARD 17)

--- a/hellocardboard-android/CMakeLists.txt
+++ b/hellocardboard-android/CMakeLists.txt
@@ -21,10 +21,10 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 add_compile_options(-Wall -Wextra)
 
 # Standard Android dependencies
-find_library(android-lib android)
-find_library(GLESv2-lib GLESv2)
-find_library(GLESv3-lib GLESv3)
-find_library(log-lib log)
+find_library(ANDROID_LIB android)
+find_library(GLESv2_LIB GLESv2)
+find_library(GLESv3_LIB GLESv3)
+find_library(LOG_LIB log)
 
 set(libs_dir ${CMAKE_CURRENT_SOURCE_DIR}/libraries)
 
@@ -37,8 +37,8 @@ add_library(cardboard_jni SHARED ${native_srcs})
 target_include_directories(cardboard_jni PRIVATE ${libs_dir})
 # Build
 target_link_libraries(cardboard_jni
-    ${android-lib}
-    ${GLESv2-lib}
-    ${GLESv3-lib}
-    ${log-lib}
+    ${ANDROID_LIB}
+    ${GLESv2_LIB}
+    ${GLESv3_LIB}
+    ${LOG_LIB}
     ${libs_dir}/jni/${ANDROID_ABI}/libGfxPluginCardboard.so)

--- a/hellocardboard-android/build.gradle
+++ b/hellocardboard-android/build.gradle
@@ -36,6 +36,9 @@ android {
     externalNativeBuild.cmake {
         path "CMakeLists.txt"
     }
+    buildFeatures {
+        prefab true
+    }
     namespace 'com.google.cardboard'
 }
 
@@ -49,27 +52,3 @@ dependencies {
     implementation 'com.google.protobuf:protobuf-javalite:3.19.4'
     implementation project(":sdk")
 }
-
-// The dependencies for NDK builds live inside the .aar files so they need to
-// be extracted before NDK targets can link against.
-task extractNdk(type: Copy)  {
-    if (file("${project.rootDir}/sdk/build/outputs/aar/sdk-release.aar").exists()) {
-        copy {
-            from zipTree("${project.rootDir}/sdk/build/outputs/aar/sdk-release.aar")
-            into "libraries/"
-            include "jni/**/libGfxPluginCardboard.so"
-        }
-        copy {
-            from "${project.rootDir}/sdk/include/cardboard.h"
-            into "libraries/"
-        }
-    }
-}
-
-task deleteNdk(type: Delete) {
-    delete "libraries/jni"
-    delete "libraries/cardboard.h"
-}
-
-build.dependsOn(extractNdk)
-clean.dependsOn(deleteNdk)

--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -112,3 +112,16 @@ target_link_libraries(GfxPluginCardboard
     # is not needed
     dl
 )
+
+set_property(
+    TARGET GfxPluginCardboard
+    APPEND_STRING
+    PROPERTY
+        LINK_FLAGS
+        " -Wl,--version-script=\"${CMAKE_CURRENT_SOURCE_DIR}/cardboard_api.lds\""
+)
+set_property(
+    TARGET GfxPluginCardboard
+    APPEND
+    PROPERTY LINK_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/cardboard_api.lds"
+)

--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.4.1)
+cmake_minimum_required(VERSION 3.22.1)
+project(cardboard_sdk VERSION 1.0.0 LANGUAGES CXX)
 
 # C++ flags.
 set(CMAKE_CXX_STANDARD 17)
@@ -101,6 +102,7 @@ add_definitions(-DVK_USE_PLATFORM_ANDROID_KHR=1)
 
 # Build
 target_link_libraries(GfxPluginCardboard
+    PUBLIC
     ${android-lib}
     ${GLESv2-lib}
     # #gles3 - Library is only needed if OpenGL ES 3.0 support is desired.

--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -20,6 +20,11 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 add_compile_options(-Wall -Wextra)
 
+# If these are already defined, the existing value is used, rather then the default here.
+option(CARDBOARDSDK_RENDERING_GLESv3 "Enable rendering with GLESv3" ON)
+option(CARDBOARDSDK_RENDERING_VULKAN "Enable rendering with Vulkan" ON)
+option(CARDBOARDSDK_UNITY_PLUGIN "Enable use as a Unity plugin" ON)
+
 # Standard Android dependencies
 find_library(ANDROID_LIB android)
 find_library(GLESv2_LIB GLESv2)
@@ -27,7 +32,9 @@ find_library(LOG_LIB log)
 
 # #gles3 - Library is only needed if OpenGL ES 3.0 support is desired. Remove
 # the following line if OpenGL ES 3.0 support is not needed.
-find_library(GLESv3_LIB GLESv3)
+if(CARDBOARDSDK_RENDERING_GLESv3)
+    find_library(GLESv3_LIB GLESv3)
+endif()
 
 include_directories(.)
 
@@ -51,22 +58,27 @@ file(GLOB screen_params_srcs "screen_params/android/*.cc")
 file(GLOB device_params_srcs "device_params/android/*.cc")
 # Rendering Sources
 file(GLOB rendering_opengl_srcs "rendering/opengl_*.cc")
-# #vulkan This is required for Vulkan rendering. Remove the following two lines
-# if Vulkan rendering is not needed.
-file(GLOB rendering_vulkan_srcs "rendering/android/*.cc")
-file(GLOB rendering_vulkan_wrapper_srcs "rendering/android/vulkan/*.cc")
 
-# === Cardboard Unity JNI ===
-file(GLOB cardboard_unity_jni_srcs "unity/android/*.cc")
+if(CARDBOARDSDK_RENDERING_VULKAN)
+    # #vulkan This is required for Vulkan rendering. Remove the following two lines
+    # if Vulkan rendering is not needed.
+    file(GLOB rendering_vulkan_srcs "rendering/android/*.cc")
+    file(GLOB rendering_vulkan_wrapper_srcs "rendering/android/vulkan/*.cc")
+endif()
 
-# === Cardboard Unity Wrapper ===
-file(GLOB cardboard_xr_unity_srcs
-  "unity/xr_unity_plugin/*.cc"
-  "unity/xr_unity_plugin/vulkan/*.cc"
-)
+if(CARDBOARDSDK_UNITY_PLUGIN)
+    # === Cardboard Unity JNI ===
+    file(GLOB cardboard_unity_jni_srcs "unity/android/*.cc")
 
-# === Cardboard XR Provider for Unity ===
-file(GLOB cardboard_xr_provider_srcs "unity/xr_provider/*.cc")
+    # === Cardboard Unity Wrapper ===
+    file(GLOB cardboard_xr_unity_srcs
+    "unity/xr_unity_plugin/*.cc"
+    "unity/xr_unity_plugin/vulkan/*.cc"
+    )
+
+    # === Cardboard XR Provider for Unity ===
+    file(GLOB cardboard_xr_provider_srcs "unity/xr_provider/*.cc")
+endif()
 
 # Output binary
 add_library(GfxPluginCardboard SHARED
@@ -92,25 +104,41 @@ add_library(GfxPluginCardboard SHARED
     # Cardboard XR Provider for Unity sources
     ${cardboard_xr_provider_srcs})
 
-# Includes
-target_include_directories(GfxPluginCardboard
-    PRIVATE ../third_party/unity_plugin_api)
+if(CARDBOARDSDK_UNITY_PLUGIN)
+    # Includes
+    target_include_directories(GfxPluginCardboard
+        PRIVATE ../third_party/unity_plugin_api)
+endif()
 
-# #vulkan This is required for Vulkan rendering. Remove the following line if
-# Vulkan rendering is not needed.
-add_definitions(-DVK_USE_PLATFORM_ANDROID_KHR=1)
+if(CARDBOARDSDK_RENDERING_VULKAN)
+    # #vulkan This is required for Vulkan rendering. Remove the following line if
+    # Vulkan rendering is not needed.
+    target_compile_definitions(GfxPluginCardboard PUBLIC VK_USE_PLATFORM_ANDROID_KHR=1)
+endif()
 
 # Build
 target_link_libraries(GfxPluginCardboard
     PUBLIC
     ${ANDROID_LIB}
     ${GLESv2_LIB}
-    # #gles3 - Library is only needed if OpenGL ES 3.0 support is desired.
-    # Remove the following line if OpenGL ES 3.0 support is not needed.
-    ${GLESv3_LIB}
     ${LOG_LIB}
-    # #vulkan - This is required for Vulkan rendering (it is required to load
-    # libvulkan.so at runtime). Remove the following line if Vulkan rendering
-    # is not needed
-    dl
 )
+
+if(CARDBOARDSDK_RENDERING_VULKAN)
+    target_link_libraries(GfxPluginCardboard
+        PUBLIC
+        # #vulkan - This is required for Vulkan rendering (it is required to load
+        # libvulkan.so at runtime). Remove the following line if Vulkan rendering
+        # is not needed
+        dl
+    )
+endif()
+
+if(CARDBOARDSDK_RENDERING_GLESv3)
+    target_link_libraries(GfxPluginCardboard
+        PUBLIC
+        # #gles3 - Library is only needed if OpenGL ES 3.0 support is desired.
+        # Remove the following line if OpenGL ES 3.0 support is not needed.
+        ${GLESv3_LIB}
+    )
+endif()

--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -21,13 +21,13 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 add_compile_options(-Wall -Wextra)
 
 # Standard Android dependencies
-find_library(android-lib android)
-find_library(GLESv2-lib GLESv2)
-find_library(log-lib log)
+find_library(ANDROID_LIB android)
+find_library(GLESv2_LIB GLESv2)
+find_library(LOG_LIB log)
 
 # #gles3 - Library is only needed if OpenGL ES 3.0 support is desired. Remove
 # the following line if OpenGL ES 3.0 support is not needed.
-find_library(GLESv3-lib GLESv3)
+find_library(GLESv3_LIB GLESv3)
 
 include_directories(.)
 
@@ -51,8 +51,8 @@ file(GLOB screen_params_srcs "screen_params/android/*.cc")
 file(GLOB device_params_srcs "device_params/android/*.cc")
 # Rendering Sources
 file(GLOB rendering_opengl_srcs "rendering/opengl_*.cc")
-# #vulkan This is required for Vulkan rendering. Remove the following two lines
-# if Vulkan rendering is not needed.
+# #vulkan This is required for Vulkan rendering. Remove the following two lines
+# if Vulkan rendering is not needed.
 file(GLOB rendering_vulkan_srcs "rendering/android/*.cc")
 file(GLOB rendering_vulkan_wrapper_srcs "rendering/android/vulkan/*.cc")
 
@@ -97,20 +97,20 @@ target_include_directories(GfxPluginCardboard
     PRIVATE ../third_party/unity_plugin_api)
 
 # #vulkan This is required for Vulkan rendering. Remove the following line if
-# Vulkan rendering is not needed.
+# Vulkan rendering is not needed.
 add_definitions(-DVK_USE_PLATFORM_ANDROID_KHR=1)
 
 # Build
 target_link_libraries(GfxPluginCardboard
     PUBLIC
-    ${android-lib}
-    ${GLESv2-lib}
+    ${ANDROID_LIB}
+    ${GLESv2_LIB}
     # #gles3 - Library is only needed if OpenGL ES 3.0 support is desired.
     # Remove the following line if OpenGL ES 3.0 support is not needed.
-    ${GLESv3-lib}
-    ${log-lib}
+    ${GLESv3_LIB}
+    ${LOG_LIB}
     # #vulkan - This is required for Vulkan rendering (it is required to load
     # libvulkan.so at runtime). Remove the following line if Vulkan rendering
-    # is not needed
+    # is not needed
     dl
 )

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -46,6 +46,14 @@ android {
         main.proto.srcDirs = ["${project.rootDir}/proto"]
         main.proto.includes = ["cardboard_device.proto"]
     }
+    buildFeatures {
+        prefabPublishing true
+    }
+    prefab {
+        GfxPluginCardboard {
+            headers "include"
+        }
+    }
     namespace 'com.google.cardboard.sdk'
 }
 

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -22,7 +22,7 @@ android {
             abiFilters 'armeabi-v7a', 'arm64-v8a'
         }
         externalNativeBuild.cmake {
-            arguments "-DANDROID_STL=c++_static"
+            arguments "-DANDROID_STL=c++_shared"
         }
         defaultConfig {
             consumerProguardFiles 'proguard-rules.pro'

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -18,9 +18,6 @@ android {
         minSdkVersion 26
         targetSdkVersion 33
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
-        ndk {
-            abiFilters 'armeabi-v7a', 'arm64-v8a'
-        }
         externalNativeBuild.cmake {
             arguments "-DANDROID_STL=c++_shared"
         }


### PR DESCRIPTION
This builds on #483 and #482 .

"Prefab" is the way to go these days for native libraries in Android build systems. Switching to prefab here gives us a few advantages, including simplified build scripts, and build dependencies that actually work (`./gradlew hellocardboard-android:installDebug` in a fresh clone actually works properly.)

There are a few quirks. I had to switch to the shared C++ runtime for the SDK so it would be acceptable to use in a shared library linked to another C++ project, per the rules of the AGP. This is actually overkill, since the cardboard SDK only exports C symbols, but I didn't see a way in AGP to override the exposed STL in the prefab metadata. (Ideally we would build against the static and have the prefab report "NONE", because of only exporting C symbols, but I couldn't figure out how to do that in Gradle. In [another project I maintain](https://github.com/KhronosGroup/OpenXR-SDK-Source/blob/main/maintainer-scripts/build-aar.sh), I make the prefab metadata files manually, building with CMake and packing with a bash script rather than gradle to get this working.)

So the prefab isn't ideal for use outside the project, but within a single project (e.g. as a submodule) it appears to work great!