### PR TITLE
Fix missing includes in cardboard.

### DIFF
--- a/sdk/lens_distortion.cc
+++ b/sdk/lens_distortion.cc
@@ -15,8 +15,12 @@
  */
 #include "lens_distortion.h"
 
+#include <algorithm>
+#include <array>
 #include <cmath>
 #include <cstring>
+#include <memory>
+#include <vector>
 
 #include "include/cardboard.h"
 #include "screen_params.h"

--- a/sdk/qrcode/android/qr_code.cc
+++ b/sdk/qrcode/android/qr_code.cc
@@ -19,6 +19,7 @@
 
 #include <array>
 #include <atomic>
+#include <cstring>
 
 #include "jni_utils/android/jni_utils.h"
 
@@ -148,7 +149,7 @@ void saveDeviceParams(const uint8_t* uri, int size) {
 
   // Copy the uint8_t* to a jbyteArray
   jbyte* java_data_ptr = env->GetByteArrayElements(uri_jbyte_array, 0);
-  memcpy(java_data_ptr, uri, size);
+  std::memcpy(java_data_ptr, uri, size);
   env->SetByteArrayRegion(uri_jbyte_array, 0, size, java_data_ptr);
 
   // Get the Java class method to be called

--- a/sdk/sensors/accelerometer_data.h
+++ b/sdk/sensors/accelerometer_data.h
@@ -16,6 +16,8 @@
 #ifndef CARDBOARD_SDK_SENSORS_ACCELEROMETER_DATA_H_
 #define CARDBOARD_SDK_SENSORS_ACCELEROMETER_DATA_H_
 
+#include <cstdint>
+
 #include "util/vector.h"
 
 namespace cardboard {

--- a/sdk/sensors/gyroscope_data.h
+++ b/sdk/sensors/gyroscope_data.h
@@ -16,6 +16,8 @@
 #ifndef CARDBOARD_SDK_SENSORS_GYROSCOPE_DATA_H_
 #define CARDBOARD_SDK_SENSORS_GYROSCOPE_DATA_H_
 
+#include <cstdint>
+
 #include "util/vector.h"
 
 namespace cardboard {

--- a/sdk/sensors/lowpass_filter.h
+++ b/sdk/sensors/lowpass_filter.h
@@ -17,6 +17,7 @@
 #define CARDBOARD_SDK_SENSORS_LOWPASS_FILTER_H_
 
 #include <array>
+#include <cstdint>
 #include <memory>
 
 #include "util/vector.h"


### PR DESCRIPTION
These result in compile failures when attempting to build chrome with clang modules on android.